### PR TITLE
Per triangle user data

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -788,6 +788,7 @@ JPH_CAPI uint32_t JPH_Shape_GetSubShapeIDBitsRecursive(const JPH_Shape* shape);
 JPH_CAPI void JPH_Shape_GetWorldSpaceBounds(const JPH_Shape* shape, JPH_RMatrix4x4* centerOfMassTransform, JPH_Vec3* scale, JPH_AABox* result);
 JPH_CAPI float JPH_Shape_GetInnerRadius(const JPH_Shape* shape);
 JPH_CAPI void JPH_Shape_GetMassProperties(const JPH_Shape* shape, JPH_MassProperties* result);
+JPH_CAPI const JPH_Shape* JPH_Shape_GetLeafShape(const JPH_Shape* shape, JPH_SubShapeID subShapeID, JPH_SubShapeID* remainder);
 JPH_CAPI const JPH_PhysicsMaterial* JPH_Shape_GetMaterial(const JPH_Shape* shape, JPH_SubShapeID subShapeID);
 JPH_CAPI void JPH_Shape_GetSurfaceNormal(const JPH_Shape* shape, JPH_SubShapeID subShapeID, JPH_Vec3* localPosition, JPH_Vec3* normal);
 JPH_CAPI float JPH_Shape_GetVolume(const JPH_Shape* shape);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -870,8 +870,11 @@ JPH_CAPI uint32_t JPH_ConvexHullShape_GetFaceVertices(const JPH_ConvexHullShape*
 /* MeshShape */
 JPH_CAPI JPH_MeshShapeSettings* JPH_MeshShapeSettings_Create(const JPH_Triangle* triangles, uint32_t triangleCount);
 JPH_CAPI JPH_MeshShapeSettings* JPH_MeshShapeSettings_Create2(const JPH_Vec3* vertices, uint32_t verticesCount, const JPH_IndexedTriangle* triangles, uint32_t triangleCount);
+JPH_CAPI bool JPH_MeshShapeSettings_GetPerTriangleUserData(const JPH_MeshShapeSettings* settings);
+JPH_CAPI void JPH_MeshShapeSettings_SetPerTriangleUserData(JPH_MeshShapeSettings* settings, bool perTriangleUserData);
 JPH_CAPI void JPH_MeshShapeSettings_Sanitize(JPH_MeshShapeSettings* settings);
 JPH_CAPI JPH_MeshShape* JPH_MeshShapeSettings_CreateShape(const JPH_MeshShapeSettings* settings);
+JPH_CAPI uint32_t JPH_MeshShape_GetTriangleUserData(const JPH_MeshShape* shape, JPH_SubShapeID id);
 
 /* HeightFieldShape */
 JPH_CAPI JPH_HeightFieldShapeSettings* JPH_HeightFieldShapeSettings_Create(const float* samples, const JPH_Vec3* offset, const JPH_Vec3* scale, uint32_t sampleCount);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -1026,6 +1026,17 @@ void JPH_Shape_GetMassProperties(const JPH_Shape* shape, JPH_MassProperties* res
 	FromJolt(joltShape->GetMassProperties(), result);
 }
 
+const JPH_Shape* JPH_Shape_GetLeafShape(const JPH_Shape* shape, JPH_SubShapeID subShapeID, JPH_SubShapeID* remainder)
+{
+	auto joltShape = reinterpret_cast<const JPH::Shape*>(shape);
+	auto joltSubShapeID = JPH::SubShapeID();
+	joltSubShapeID.SetValue(subShapeID);
+	JPH::SubShapeID joltRemainder = JPH::SubShapeID();
+	const JPH::Shape* leaf = joltShape->GetLeafShape(joltSubShapeID, joltRemainder);
+	*remainder = joltRemainder.GetValue();
+	return reinterpret_cast<const JPH_Shape*>(leaf);
+}
+
 const JPH_PhysicsMaterial* JPH_Shape_GetMaterial(const JPH_Shape* shape, JPH_SubShapeID subShapeID)
 {
 	auto joltShape = reinterpret_cast<const JPH::Shape*>(shape);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -1494,6 +1494,16 @@ JPH_MeshShapeSettings* JPH_MeshShapeSettings_Create2(const JPH_Vec3* vertices, u
 	return reinterpret_cast<JPH_MeshShapeSettings*>(settings);
 }
 
+bool JPH_MeshShapeSettings_GetPerTriangleUserData(const JPH_MeshShapeSettings* settings)
+{
+	return reinterpret_cast<const JPH::MeshShapeSettings*>(settings)->mPerTriangleUserData;
+}
+
+void JPH_MeshShapeSettings_SetPerTriangleUserData(JPH_MeshShapeSettings* settings, bool perTriangleUserData)
+{
+	reinterpret_cast<JPH::MeshShapeSettings*>(settings)->mPerTriangleUserData = perTriangleUserData;
+}
+
 void JPH_MeshShapeSettings_Sanitize(JPH_MeshShapeSettings* settings)
 {
 	JPH_ASSERT(settings != nullptr);
@@ -1510,6 +1520,13 @@ JPH_MeshShape* JPH_MeshShapeSettings_CreateShape(const JPH_MeshShapeSettings* se
 	shape->AddRef();
 
 	return reinterpret_cast<JPH_MeshShape*>(shape);
+}
+
+uint32_t JPH_MeshShape_GetTriangleUserData(const JPH_MeshShape* shape, JPH_SubShapeID id)
+{
+	JPH::SubShapeID joltSubShapeID = JPH::SubShapeID();
+	joltSubShapeID.SetValue(id);
+	return reinterpret_cast<const JPH::MeshShape*>(shape)->GetTriangleUserData(joltSubShapeID);
 }
 
 /* HeightFieldShapeSettings */


### PR DESCRIPTION
Adds bindings for `MeshShape::GetTriangleUserData`, `MeshShapeSettings::mPerTriangleUserData`, and `Shape::GetLeafShape`.  This allows us to get the triangle index that was hit by a raycast.

Let me know if you'd like to see any changes!

*(Note: I haven't tested this yet so there may be issues, will remove this once it's tested in LÖVR)*