### PR TITLE
JPH_JobSystem;

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -730,6 +730,23 @@ typedef struct JPH_CharacterVirtual                 JPH_CharacterVirtual;  /* In
 typedef void(JPH_API_CALL* JPH_TraceFunc)(const char* mssage);
 typedef bool(JPH_API_CALL* JPH_AssertFailureFunc)(const char* expression, const char* mssage, const char* file, uint32_t line);
 
+typedef void JPH_JobFunction(void* arg);
+typedef void JPH_QueueJobCallback(void* context, JPH_JobFunction* job, void* arg);
+typedef void JPH_QueueJobsCallback(void* context, JPH_JobFunction* job, void** args, uint32_t count);
+
+typedef struct {
+	void* context;
+	JPH_QueueJobCallback* queueJob;
+	JPH_QueueJobsCallback* queueJobs;
+	uint32_t maxConcurrency;
+} JPH_JobSystemConfig;
+
+typedef struct JPH_JobSystem JPH_JobSystem;
+
+JPH_CAPI JPH_JobSystem* JPH_JobSystemThreadPool_Create(void);
+JPH_CAPI JPH_JobSystem* JPH_JobSystemCallback_Create(const JPH_JobSystemConfig* config);
+JPH_CAPI void JPH_JobSystem_Destroy(JPH_JobSystem* jobSystem);
+
 JPH_CAPI bool JPH_Init(void);
 JPH_CAPI void JPH_Shutdown(void);
 JPH_CAPI void JPH_SetTraceHandler(JPH_TraceFunc handler);
@@ -810,8 +827,8 @@ JPH_CAPI void JPH_PhysicsSystem_SetPhysicsSettings(JPH_PhysicsSystem* system, JP
 JPH_CAPI void JPH_PhysicsSystem_GetPhysicsSettings(JPH_PhysicsSystem* system, JPH_PhysicsSettings* result);
 
 JPH_CAPI void JPH_PhysicsSystem_OptimizeBroadPhase(JPH_PhysicsSystem* system);
-JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Update(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps);
-JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Step(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps);
+JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Update(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_JobSystem* jobSystem);
+JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Step(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_JobSystem* jobSystem);
 
 JPH_CAPI JPH_BodyInterface* JPH_PhysicsSystem_GetBodyInterface(JPH_PhysicsSystem* system);
 JPH_CAPI JPH_BodyInterface* JPH_PhysicsSystem_GetBodyInterfaceNoLock(JPH_PhysicsSystem* system);

--- a/samples/01_HelloWorld/main.cpp
+++ b/samples/01_HelloWorld/main.cpp
@@ -36,6 +36,8 @@ int main(void)
 	JPH_SetTraceHandler(TraceImpl);
 	//JPH_SetAssertFailureHandler(JPH_AssertFailureFunc handler);
 
+  JPH_JobSystem* jobSystem = JPH_JobSystemThreadPool_Create();
+
 	// We use only 2 layers: one for non-moving objects and one for moving objects
 	JPH_ObjectLayerPairFilter* objectLayerPairFilterTable = JPH_ObjectLayerPairFilterTable_Create(2);
 	JPH_ObjectLayerPairFilterTable_EnableCollision(objectLayerPairFilterTable, Layers::NON_MOVING, Layers::MOVING);
@@ -149,7 +151,7 @@ int main(void)
 		const int cCollisionSteps = 1;
 
 		// Step the world
-		JPH_PhysicsSystem_Update(system, cDeltaTime, cCollisionSteps);
+		JPH_PhysicsSystem_Update(system, cDeltaTime, cCollisionSteps, jobSystem);
 	}
 
 	// Remove the destroy sphere from the physics system. Note that the sphere itself keeps all of its state and can be re-added at any time.
@@ -157,6 +159,8 @@ int main(void)
 
 	// Remove and destroy the floor
 	JPH_BodyInterface_RemoveAndDestroyBody(bodyInterface, floorId);
+
+  JPH_JobSystem_Destroy(jobSystem);
 
 	JPH_PhysicsSystem_Destroy(system);
 	JPH_Shutdown();

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -416,9 +416,95 @@ static JPH::IndexedTriangle ToIndexedTriangle(const JPH_IndexedTriangle& triangl
 
 // 10 MB was not enough for large simulation, let's use TempAllocatorMalloc
 static TempAllocator* s_TempAllocator = nullptr;
-static JobSystemThreadPool* s_JobSystem = nullptr;
 
-bool JPH_Init(void)
+class JobSystemCallback final : public JPH::JobSystemWithBarrier
+{
+public:
+	JobSystemCallback(const JPH_JobSystemConfig* config)
+	{
+		JobSystemWithBarrier::Init(JPH::cMaxPhysicsBarriers);
+		mJobs.Init(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsJobs);
+		mConfig = *config;
+	}
+
+	virtual JobHandle CreateJob(const char* name, JPH::ColorArg color, const JPH::JobSystem::JobFunction& callback, uint32_t dependencies = 0) override
+	{
+		uint32_t index;
+
+		for (;;)
+		{
+			index = mJobs.ConstructObject(name, color, this, callback, dependencies);
+			if (index != FixedSizeFreeList<Job>::cInvalidObjectIndex)
+				break;
+			JPH_ASSERT(false, "No jobs available!");
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
+		}
+
+		Job* job = &mJobs.Get(index);
+		JobHandle handle(job);
+
+		if (dependencies == 0)
+			QueueJob(job);
+
+		return handle;
+	}
+
+	virtual void FreeJob(Job* job) override
+	{
+		mJobs.DestructObject(job);
+	}
+
+	virtual int GetMaxConcurrency() const override
+	{
+		return mConfig.maxConcurrency;
+	}
+
+protected:
+	static void RunJob(void* arg)
+	{
+		Job* job = reinterpret_cast<Job*>(arg);
+		job->Execute();
+		job->Release();
+	}
+
+	virtual void QueueJob(Job* job) override
+	{
+		job->AddRef();
+		mConfig.queueJob(mConfig.context, RunJob, job);
+	}
+
+	virtual void QueueJobs(Job** jobs, uint32_t count) override
+	{
+		for (uint32_t i = 0; i < count; i++) {
+			jobs[i]->AddRef();
+		}
+
+		mConfig.queueJobs(mConfig.context, RunJob, (void**) jobs, count);
+	}
+
+private:
+	FixedSizeFreeList<Job> mJobs;
+	JPH_JobSystemConfig mConfig;
+};
+
+JPH_JobSystem* JPH_JobSystemThreadPool_Create(void)
+{
+	JPH::JobSystem* jobSystem = new JPH::JobSystemThreadPool(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers, (int) std::thread::hardware_concurrency() - 1);
+	return reinterpret_cast<JPH_JobSystem*>(jobSystem);
+}
+
+JPH_JobSystem* JPH_JobSystemCallback_Create(const JPH_JobSystemConfig* config)
+{
+	JPH::JobSystem* jobSystem = new JobSystemCallback(config);
+	return reinterpret_cast<JPH_JobSystem*>(jobSystem);
+}
+
+void JPH_JobSystem_Destroy(JPH_JobSystem* jobSystem)
+{
+	delete reinterpret_cast<JPH::JobSystem*>(jobSystem);
+}
+
+bool JPH_Init()
 {
 	JPH::RegisterDefaultAllocator();
 
@@ -435,15 +521,11 @@ bool JPH_Init(void)
 	// Init temp allocator
 	s_TempAllocator = new TempAllocatorImplWithMallocFallback(8 * 1024 * 1024);
 
-	// Init Job system.
-	s_JobSystem = new JPH::JobSystemThreadPool(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers, (int)std::thread::hardware_concurrency() - 1);
-
 	return true;
 }
 
 void JPH_Shutdown(void)
 {
-	delete s_JobSystem; s_JobSystem = nullptr;
 	delete s_TempAllocator; s_TempAllocator = nullptr;
 
 	// Unregisters all types with the factory and cleans up the default material
@@ -712,14 +794,16 @@ void JPH_PhysicsSystem_OptimizeBroadPhase(JPH_PhysicsSystem* system)
 	system->physicsSystem->OptimizeBroadPhase();
 }
 
-JPH_PhysicsUpdateError JPH_PhysicsSystem_Update(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps)
+JPH_PhysicsUpdateError JPH_PhysicsSystem_Update(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_JobSystem* jobSystem)
 {
-	return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, s_TempAllocator, s_JobSystem));
+	JPH::JobSystem* joltJobSystem = reinterpret_cast<JPH::JobSystem*>(jobSystem);
+	return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, s_TempAllocator, joltJobSystem));
 }
 
-JPH_PhysicsUpdateError JPH_PhysicsSystem_Step(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps)
+JPH_PhysicsUpdateError JPH_PhysicsSystem_Step(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_JobSystem* jobSystem)
 {
-	return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, s_TempAllocator, s_JobSystem));
+	JPH::JobSystem* joltJobSystem = reinterpret_cast<JPH::JobSystem*>(jobSystem);
+	return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, s_TempAllocator, joltJobSystem));
 }
 
 JPH_BodyInterface* JPH_PhysicsSystem_GetBodyInterface(JPH_PhysicsSystem* system)


### PR DESCRIPTION
I've been thinking about how to let people use their own job system when using joltc.  LÖVR has its own job system but doesn't have a way to tell joltc to use it.  Here's what I've come up with so far and it works, curious what your thoughts are.

- `JPH_PhysicsSystem_Update` takes a `JPH_JobSystem` now, just like the C++ API does (this would be a breaking change).
- You're expected to create the job system yourself, with 2 choices:
  - `JPH_JobSystemThreadPool_Create`: use Jolt's default job system, like joltc does today.
  - `JPH_JobSystemCallback_Create`: use your own job system.  You pass in callbacks that run a job (or multiple jobs), and the number of worker threads you have.

The implementation has a new `JobSystemCallback` C++ glue class that is mostly a copy of Jolt's `JobSystemThreadPool` without the job queue and thread pool.  It just calls the user's C callback whenever a job is queued.

There are some (in my opinion) issues with Jolt's job system design that make it a little hard to use.  Jolt doesn't tell you when it wants to wait for a job and signal it as finished, so you have to keep all jobs around during the physics update, and "drain" them all after the update is finished.  This is what godot-jolt does and I think it's the only workable approach, but it means that you'll have more jobs in flight than needed.