### PR TITLE
Add allowed DOFs to character settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ endif ()
 FetchContent_Declare(
         JoltPhysics
         GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"
-        GIT_TAG "3ede71e8104f242df72c2af8d0683fe1f1ae6970"
+        GIT_TAG "ce420fe7efa6326d02cc3c21e2ba95bb03309501"
 		SOURCE_SUBDIR "Build"
 )
 FetchContent_MakeAvailable(JoltPhysics)

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -699,11 +699,12 @@ typedef struct JPH_CharacterBase                    JPH_CharacterBase;
 
 /* Character */
 typedef struct JPH_CharacterSettings {
-	JPH_CharacterBaseSettings           base;    /* Inherics JPH_CharacterBaseSettings */
+	JPH_CharacterBaseSettings                               base;    /* Inherics JPH_CharacterBaseSettings */
 	JPH_ObjectLayer						layer;
-	float								mass;
-	float								friction;
-	float								gravityFactor;
+	float							mass;
+	float							friction;
+	float							gravityFactor;
+	JPH_AllowedDOFs                                         allowedDOFs;
 } JPH_CharacterSettings;
 typedef struct JPH_Character                        JPH_Character;  /* Inherics JPH_CharacterBase */
 

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -6805,6 +6805,7 @@ void JPH_CharacterSettings_Init(JPH_CharacterSettings* settings)
 	settings->mass = joltSettings.mMass;
 	settings->friction = joltSettings.mFriction;
 	settings->gravityFactor = joltSettings.mGravityFactor;
+	settings->allowedDOFs = static_cast<JPH_AllowedDOFs>(joltSettings.mAllowedDOFs);
 }
 
 /* Character */
@@ -6833,6 +6834,7 @@ JPH_Character* JPH_Character_Create(const JPH_CharacterSettings* settings,
 	joltSettings.mMass = settings->mass;
 	joltSettings.mFriction = settings->friction;
 	joltSettings.mGravityFactor = settings->gravityFactor;
+	joltSettings.mAllowedDOFs = static_cast<EAllowedDOFs>(settings->allowedDOFs);
 
 	auto joltCharacter = new JPH::Character(&joltSettings,
 		ToJolt(position),


### PR DESCRIPTION
Exposes the mAllowedDOFs setting in character settings added in this PR:

https://github.com/jrouwe/JoltPhysics/pull/1433

Also bumps the commit version by one commit to catch ^