### PR TITLE
Add CollisionDispatch methods

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2204,6 +2204,30 @@ JPH_CAPI void JPH_CharacterVsCharacterCollisionSimple_AddCharacter(JPH_Character
 JPH_CAPI void JPH_CharacterVsCharacterCollisionSimple_RemoveCharacter(JPH_CharacterVsCharacterCollision* characterVsCharacter, JPH_CharacterVirtual* character);
 JPH_CAPI void JPH_CharacterVsCharacterCollision_Destroy(JPH_CharacterVsCharacterCollision* listener);
 
+/* CollisionDispatch */
+JPH_CAPI bool JPH_CollisionDispatch_CollideShapeVsShape(
+	const JPH_Shape* inShape1, const JPH_Shape* inShape2,
+	JPH_Vec3* inScale1, JPH_Vec3* inScale2,
+	JPH_Matrix4x4* inCenterOfMassTransform1, JPH_Matrix4x4* inCenterOfMassTransform2,
+	const JPH_CollideShapeSettings* inCollideShapeSettings,
+	JPH_CollideShapeCollectorCallback* callback, void* userData, const JPH_ShapeFilter* inShapeFilter);
+
+JPH_CAPI bool JPH_CollisionDispatch_CastShapeVsShapeLocalSpace(
+	JPH_Vec3* inDirection, const JPH_Shape* inShape1, const JPH_Shape* inShape2,
+	JPH_Vec3* inScale1InShape2LocalSpace, JPH_Vec3* inScale2,
+	JPH_Matrix4x4* inCenterOfMassTransform1InShape2LocalSpace, JPH_Matrix4x4* inCenterOfMassWorldTransform2,
+	const JPH_ShapeCastSettings* inShapeCastSettings,
+	JPH_CastShapeCollectorCallback* callback, void* userData,
+	const JPH_ShapeFilter* inShapeFilter);
+
+JPH_CAPI bool JPH_CollisionDispatch_CastShapeVsShapeWorldSpace(
+	JPH_Vec3* inDirection, const JPH_Shape* inShape1, const JPH_Shape* inShape2,
+	JPH_Vec3* inScale1, JPH_Vec3* inScale2,
+	JPH_Matrix4x4* inCenterOfMassWorldTransform1, JPH_Matrix4x4* inCenterOfMassWorldTransform2,
+	const JPH_ShapeCastSettings* inShapeCastSettings,
+	JPH_CastShapeCollectorCallback* callback, void* userData,
+	const JPH_ShapeFilter* inShapeFilter);
+
 /* DebugRenderer */
 typedef struct JPH_DebugRenderer_Procs {
 	void (JPH_API_CALL* DrawLine)(void* userData, const JPH_RVec3* from, const JPH_RVec3* to, JPH_Color color);


### PR DESCRIPTION
CollisionDispatch exposes static methods for shape vs shape casting/colliding.

These may need further testing.