### PR TITLE
Add EstimateCollisionResponse and CollisionEstimationResult bindings

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -654,6 +654,14 @@ typedef struct JPH_ContactListener                  JPH_ContactListener;
 typedef struct JPH_ContactManifold                  JPH_ContactManifold;
 typedef struct JPH_ContactSettings                  JPH_ContactSettings;
 
+typedef struct JPH_CollisionEstimationResult		JPH_CollisionEstimationResult;
+
+typedef struct JPH_CollisionEstimationResultImpulse {
+	float ContactImpulse;
+	float FrictionImpulse1;
+	float FrictionImpulse2;
+} JPH_CollisionEstimationResultImpulse;
+
 typedef struct JPH_BodyActivationListener           JPH_BodyActivationListener;
 typedef struct JPH_BodyDrawFilter                   JPH_BodyDrawFilter;
 
@@ -2390,5 +2398,18 @@ JPH_CAPI void JPH_Ragdoll_RemoveFromPhysicsSystem(JPH_Ragdoll* ragdoll, bool loc
 JPH_CAPI void JPH_Ragdoll_Activate(JPH_Ragdoll* ragdoll, bool lockBodies /* = true */);
 JPH_CAPI bool JPH_Ragdoll_IsActive(const JPH_Ragdoll* ragdoll, bool lockBodies /* = true */);
 JPH_CAPI void JPH_Ragdoll_ResetWarmStart(JPH_Ragdoll* ragdoll);
+
+/* CollisionEstimationResult */
+JPH_CAPI void JPH_CollisionEstimationResult_Destroy(JPH_CollisionEstimationResult* collisionEstimationResult);
+JPH_CAPI void JPH_CollisionEstimationResult_GetLinearVelocity1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* linearVelocity);
+JPH_CAPI void JPH_CollisionEstimationResult_GetLinearVelocity2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* linearVelocity);
+JPH_CAPI void JPH_CollisionEstimationResult_GetAngularVelocity1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* angularVelocity);
+JPH_CAPI void JPH_CollisionEstimationResult_GetAngularVelocity2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* angularVelocity);
+JPH_CAPI void JPH_CollisionEstimationResult_GetTangent1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* tangent);
+JPH_CAPI void JPH_CollisionEstimationResult_GetTangent2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* tangent);
+JPH_CAPI uint32_t JPH_CollisionEstimationResult_GetImpulsesCount(JPH_CollisionEstimationResult* collisionEstimationResult);
+JPH_CAPI void JPH_CollisionEstimationResult_GetImpulse(JPH_CollisionEstimationResult* collisionEstimationResult, uint32_t index, JPH_CollisionEstimationResultImpulse* impulse);
+
+JPH_CAPI JPH_CollisionEstimationResult* JPH_EstimateCollisionResponse(JPH_Body* body1, JPH_Body* body2, JPH_ContactManifold* manifold, float combinedFriction, float combinedRestitution, float minVelocityForRestitution, uint32_t numIterations);
 
 #endif /* JOLT_C_H_ */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -26,6 +26,7 @@ JPH_SUPPRESS_WARNINGS
 #include "Jolt/Physics/Collision/CollideShape.h"
 #include <Jolt/Physics/Collision/CollisionCollectorImpl.h>
 #include <Jolt/Physics/Collision/CollisionDispatch.h>
+#include <Jolt/Physics/Collision/EstimateCollisionResponse.h>
 #include <Jolt/Physics/Collision/ShapeCast.h>
 #include "Jolt/Physics/Collision/Shape/PlaneShape.h"
 #include "Jolt/Physics/Collision/Shape/BoxShape.h"
@@ -8405,6 +8406,76 @@ bool JPH_Ragdoll_IsActive(const JPH_Ragdoll* ragdoll, bool lockBodies /* = true 
 void JPH_Ragdoll_ResetWarmStart(JPH_Ragdoll* ragdoll)
 {
 	AsRagdoll(ragdoll)->ResetWarmStart();
+}
+
+/* CollisionEstimationResult */
+void JPH_CollisionEstimationResult_Destroy(JPH_CollisionEstimationResult* collisionEstimationResult)
+{
+	if (collisionEstimationResult)
+		delete reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+}
+
+void JPH_CollisionEstimationResult_GetLinearVelocity1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* linearVelocity)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mLinearVelocity1, linearVelocity);
+}
+
+void JPH_CollisionEstimationResult_GetLinearVelocity2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* linearVelocity)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mLinearVelocity2, linearVelocity);
+}
+
+void JPH_CollisionEstimationResult_GetAngularVelocity1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* angularVelocity)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mAngularVelocity1, angularVelocity);
+}
+
+void JPH_CollisionEstimationResult_GetAngularVelocity2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* angularVelocity)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mAngularVelocity2, angularVelocity);
+}
+
+void JPH_CollisionEstimationResult_GetTangent1(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* tangent)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mTangent1, tangent);
+}
+
+void JPH_CollisionEstimationResult_GetTangent2(JPH_CollisionEstimationResult* collisionEstimationResult, JPH_Vec3* tangent)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	FromJolt(jolt_result->mTangent2, tangent);
+}
+
+uint32_t JPH_CollisionEstimationResult_GetImpulsesCount(JPH_CollisionEstimationResult* collisionEstimationResult)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	return jolt_result->mImpulses.size();
+}
+
+void JPH_CollisionEstimationResult_GetImpulse(JPH_CollisionEstimationResult* collisionEstimationResult, uint32_t index, JPH_CollisionEstimationResultImpulse* impulse)
+{
+	auto jolt_result = reinterpret_cast<JPH::CollisionEstimationResult*>(collisionEstimationResult);
+	JPH_ASSERT(index < jolt_result->mImpulses.size());
+	auto jolt_impulse = jolt_result->mImpulses[index];
+
+	impulse->ContactImpulse = jolt_impulse.mContactImpulse;
+	impulse->FrictionImpulse1 = jolt_impulse.mFrictionImpulse1;
+	impulse->FrictionImpulse2 = jolt_impulse.mFrictionImpulse2;
+}
+
+JPH_CollisionEstimationResult* JPH_EstimateCollisionResponse(JPH_Body* body1, JPH_Body* body2, JPH_ContactManifold* manifold, float combinedFriction, float combinedRestitution, float minVelocityForRestitution, uint32_t numIterations)
+{
+	auto jolt_manifold = reinterpret_cast<JPH::ContactManifold*>(manifold);
+	JPH::CollisionEstimationResult* jolt_result = new JPH::CollisionEstimationResult();
+
+	JPH::EstimateCollisionResponse(*AsBody(body1), *AsBody(body2), *jolt_manifold, *jolt_result, combinedFriction, combinedRestitution, minVelocityForRestitution, numIterations);
+
+	return reinterpret_cast<JPH_CollisionEstimationResult*>(jolt_result);
 }
 
 JPH_SUPPRESS_WARNING_POP


### PR DESCRIPTION
Adds bindings for the `EstimateCollisionResponse` static method and the `CollisionEstimationResult` struct that can be used inside contact listeners.

