### PR TITLE
Character init now creates an empty shape if none is available

### DIFF
--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -7433,9 +7433,13 @@ void JPH_CharacterBaseSettings_Init(const CharacterBaseSettings& joltSettings, J
 	FromJolt(joltSettings.mSupportingVolume, &settings->supportingVolume);
 	settings->maxSlopeAngle = joltSettings.mMaxSlopeAngle;
 	settings->enhancedInternalEdgeRemoval = joltSettings.mEnhancedInternalEdgeRemoval;
-	if (joltSettings.mShape)
-	{
+	if (joltSettings.mShape) {
 		settings->shape = reinterpret_cast<const JPH_Shape*>(joltSettings.mShape.GetPtr());
+	} else {
+		JPH_Vec3 vec = {0.0f, 0.0f, 0.0f};
+		JPH_EmptyShapeSettings* empty_shape_settings = JPH_EmptyShapeSettings_Create(&vec);
+		JPH_EmptyShape* shape = JPH_EmptyShapeSettings_CreateShape(empty_shape_settings);
+		settings->shape = reinterpret_cast<const JPH_Shape*>(shape);
 	}
 }
 
@@ -9230,7 +9234,7 @@ void JPH_WheelSettingsWV_Init(JPH_WheelSettingsWV* settings)
 void JPH_WheelSettingsWV_ToJolt(WheelSettingsWV* joltSettings, const JPH_WheelSettingsWV& settings)
 {
 	JPH_ASSERT(joltSettings);
-	JPH_ASSERT(settings);
+	//JPH_ASSERT(settings);
 
 	// Base settings
 	JPH_WheelSettings_ToJolt(joltSettings, &settings.base);


### PR DESCRIPTION
Using the code below
```
JPH_CharacterSettings_Init
JPH_Character_Create
```
without specifying a shape to the character creates a crash during the `CreateBody -> AllocateBody -> SetPositionAndRotationInternal` while accessing `mShape->GetCenterOfMass()`.

Any place that would use this shape without a check would crash, but it ends up crashing right away during the character creation.

My commit just adds a empty shape to the character if `joltSettings.mShape` is nil during `JPH_CharacterBaseSettings_Init`.

Probably not the best solution, but it works.

---

I'm doing a [jolt-odin](https://github.com/caioraphael1/jolt-odin) binding. Feel free to check it out :)

Thanks for the joltC interface!

---

I commented an assert for `JPH_WheelSettingsWV_ToJolt`, as the code wouldn't compile otherwise, and I wasn't using vehicles anyway, but it's something to revisit