### PR TITLE
Remove assert;

### DIFF
--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -9230,7 +9230,6 @@ void JPH_WheelSettingsWV_Init(JPH_WheelSettingsWV* settings)
 void JPH_WheelSettingsWV_ToJolt(WheelSettingsWV* joltSettings, const JPH_WheelSettingsWV& settings)
 {
 	JPH_ASSERT(joltSettings);
-	JPH_ASSERT(settings);
 
 	// Base settings
 	JPH_WheelSettings_ToJolt(joltSettings, &settings.base);


### PR DESCRIPTION
Hi!  I'm currently getting a build failure with clang 14 (and gcc 11):

```
joltc/src/joltc.cpp:9233:2: error: invalid argument type 'const JPH_WheelSettingsWV' to unary expression
        JPH_ASSERT(settings);
        ^~~~~~~~~~~~~~~~~~~~
_deps/joltphysics-src/Build/../Jolt/Core/IssueReporting.h:29:49: note: expanded from macro 'JPH_ASSERT'
        #define JPH_ASSERT(inExpression, ...)   do { if (!(inExpression) && AssertFailedParamHelper(#inExpression, __FILE__, JPH::uint(__LINE__), ##__VA_ARGS__, JPH::AssertLastParam())) JPH_BREAKPOINT; } while (false)
                                                         ^~~~~~~~~~~~~~~
1 error generated.
```

Not sure how my setup is different from CI, here is how I am configuring:

```cmake
  set(BUILD_SHARED_LIBS OFF)
  set(JPH_BUILD_SHARED ON CACHE BOOL "")
  set(DEBUG_RENDERER_IN_DEBUG_AND_RELEASE OFF CACHE BOOL "")
  set(PROFILER_IN_DEBUG_AND_RELEASE OFF CACHE BOOL "")
  set(ENABLE_OBJECT_STREAM OFF CACHE BOOL "")
  if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
    set(GENERATE_DEBUG_SYMBOLS ON CACHE BOOL "")
  endif()
  add_subdirectory(deps/joltc jolt)
```

But anyway, removing the assert here fixes it!