### PR TITLE
Change static callback function pointer tables from pointer to value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,6 @@ artifacts/
 artifacts-*/
 
 build/*
+
+# Rider
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,18 +135,26 @@ if (JPH_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
 endif ()
 
-# use local JoltPhysics if exists
-set(JoltPhysics_LOCAL_PATH "${CMAKE_SOURCE_DIR}/../JoltPhysics")
+# Search for local JoltPhysics first
+if(EXISTS "${CMAKE_SOURCE_DIR}/JoltPhysics/Build/CMakeLists.txt")
+    message(STATUS "Using local JoltPhysics from ${CMAKE_SOURCE_DIR}/JoltPhysics")
 
-if(EXISTS "${JoltPhysics_LOCAL_PATH}/Build/CMakeLists.txt")
-    message(STATUS "Using local JoltPhysics at ${JoltPhysics_LOCAL_PATH}")
     FetchContent_Declare(
         JoltPhysics
-        SOURCE_DIR "${JoltPhysics_LOCAL_PATH}"
+        SOURCE_DIR "${CMAKE_SOURCE_DIR}/JoltPhysics"
+        SOURCE_SUBDIR "Build"
+    )
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/../JoltPhysics/Build/CMakeLists.txt")
+    message(STATUS "Using local JoltPhysics from ${CMAKE_SOURCE_DIR}/../JoltPhysics")
+
+    FetchContent_Declare(
+        JoltPhysics
+        SOURCE_DIR "${CMAKE_SOURCE_DIR}/../JoltPhysics"
         SOURCE_SUBDIR "Build"
     )
 else()
-    message(STATUS "not found JoltPhysics at ${JoltPhysics_LOCAL_PATH}, Downloading from GitHub jrouwe/JoltPhysics")
+    message(STATUS "Local Jolt not found, download from remote")
+
     FetchContent_Declare(
         JoltPhysics
         GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,12 +135,25 @@ if (JPH_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
 endif ()
 
-FetchContent_Declare(
-    JoltPhysics
-    GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"
-    GIT_TAG v5.3.0
-	SOURCE_SUBDIR "Build"
-)
+# use local JoltPhysics if exists
+set(JoltPhysics_LOCAL_PATH "${CMAKE_SOURCE_DIR}/../JoltPhysics")
+
+if(EXISTS "${JoltPhysics_LOCAL_PATH}/Build/CMakeLists.txt")
+    message(STATUS "Using local JoltPhysics at ${JoltPhysics_LOCAL_PATH}")
+    FetchContent_Declare(
+        JoltPhysics
+        SOURCE_DIR "${JoltPhysics_LOCAL_PATH}"
+        SOURCE_SUBDIR "Build"
+    )
+else()
+    message(STATUS "not found JoltPhysics at ${JoltPhysics_LOCAL_PATH}, Downloading from GitHub jrouwe/JoltPhysics")
+    FetchContent_Declare(
+        JoltPhysics
+        GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"
+        GIT_TAG v5.3.0
+        SOURCE_SUBDIR "Build"
+    )
+endif()
 FetchContent_MakeAvailable(JoltPhysics)
 
 if (XCODE)

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2162,8 +2162,7 @@ typedef struct JPH_ContactListener_Procs {
 		JPH_ContactSettings* settings);
 
 	void(JPH_API_CALL* OnContactRemoved)(void* userData,
-		const JPH_SubShapeIDPair* subShapePair
-		);
+		const JPH_SubShapeIDPair* subShapePair);
 } JPH_ContactListener_Procs;
 
 JPH_CAPI void JPH_ContactListener_SetProcs(const JPH_ContactListener_Procs* procs);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -643,7 +643,7 @@ typedef struct JPH_DrawSettings {
 	JPH_BodyManager_ShapeColor	drawShapeColor;                     ///< Coloring scheme to use for shapes
 	bool						drawBoundingBox;					///< Draw a bounding box per body
 	bool						drawCenterOfMassTransform;			///< Draw the center of mass for each body
-	bool						drawWorldTransform;					///< Draw the world transform (which can be different than the center of mass) for each body
+	bool						drawWorldTransform;					///< Draw the world transform (which may differ from its center of mass) of each body
 	bool						drawVelocity;						///< Draw the velocity vector for each body
 	bool						drawMassAndInertia;					///< Draw the mass and inertia (as the box equivalent) for each body
 	bool						drawSleepStats;						///< Draw stats regarding the sleeping algorithm of each body
@@ -959,8 +959,8 @@ typedef struct JPH_CharacterVirtualContact {
 	bool							canPushCharacter;
 } JPH_CharacterVirtualContact;
 
-typedef void(JPH_API_CALL* JPH_TraceFunc)(const char* mssage);
-typedef bool(JPH_API_CALL* JPH_AssertFailureFunc)(const char* expression, const char* mssage, const char* file, uint32_t line);
+typedef void(JPH_API_CALL* JPH_TraceFunc)(const char* message);
+typedef bool(JPH_API_CALL* JPH_AssertFailureFunc)(const char* expression, const char* message, const char* file, uint32_t line);
 
 typedef void JPH_JobFunction(void* arg);
 typedef void JPH_QueueJobCallback(void* context, JPH_JobFunction* job, void* arg);
@@ -1451,8 +1451,8 @@ JPH_CAPI void JPH_BodyCreationSettings_SetUserData(JPH_BodyCreationSettings* set
 JPH_CAPI JPH_ObjectLayer JPH_BodyCreationSettings_GetObjectLayer(const JPH_BodyCreationSettings* settings);
 JPH_CAPI void JPH_BodyCreationSettings_SetObjectLayer(JPH_BodyCreationSettings* settings, JPH_ObjectLayer value);
 
-JPH_CAPI void JPH_BodyCreationSettings_GetCollissionGroup(const JPH_BodyCreationSettings* settings, JPH_CollisionGroup* result);
-JPH_CAPI void JPH_BodyCreationSettings_SetCollissionGroup(JPH_BodyCreationSettings* settings, const JPH_CollisionGroup* value);
+JPH_CAPI void JPH_BodyCreationSettings_GetCollisionGroup(const JPH_BodyCreationSettings* settings, JPH_CollisionGroup* result);
+JPH_CAPI void JPH_BodyCreationSettings_SetCollisionGroup(JPH_BodyCreationSettings* settings, const JPH_CollisionGroup* value);
 
 JPH_CAPI JPH_MotionType JPH_BodyCreationSettings_GetMotionType(const JPH_BodyCreationSettings* settings);
 JPH_CAPI void JPH_BodyCreationSettings_SetMotionType(JPH_BodyCreationSettings* settings, JPH_MotionType value);
@@ -1754,8 +1754,8 @@ JPH_CAPI void JPH_BodyInterface_SetPositionAndRotationWhenChanged(JPH_BodyInterf
 JPH_CAPI void JPH_BodyInterface_GetPositionAndRotation(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_RVec3* position, JPH_Quat* rotation);
 JPH_CAPI void JPH_BodyInterface_SetPositionRotationAndVelocity(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_RVec3* position, JPH_Quat* rotation, JPH_Vec3* linearVelocity, JPH_Vec3* angularVelocity);
 
-JPH_CAPI void JPH_BodyInterface_GetCollissionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_CollisionGroup* result);
-JPH_CAPI void JPH_BodyInterface_SetCollissionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, const JPH_CollisionGroup* group);
+JPH_CAPI void JPH_BodyInterface_GetCollisionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_CollisionGroup* result);
+JPH_CAPI void JPH_BodyInterface_SetCollisionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, const JPH_CollisionGroup* group);
 
 JPH_CAPI const JPH_Shape* JPH_BodyInterface_GetShape(JPH_BodyInterface* interface, JPH_BodyID bodyId);
 JPH_CAPI void JPH_BodyInterface_SetShape(JPH_BodyInterface* interface, JPH_BodyID bodyId, const JPH_Shape* shape, bool updateMassProperties, JPH_Activation activationMode);
@@ -2024,8 +2024,8 @@ JPH_CAPI void JPH_Body_SetMotionType(JPH_Body* body, JPH_MotionType motionType);
 JPH_CAPI JPH_BroadPhaseLayer JPH_Body_GetBroadPhaseLayer(const JPH_Body* body);
 JPH_CAPI JPH_ObjectLayer JPH_Body_GetObjectLayer(const JPH_Body* body);
 
-JPH_CAPI void JPH_Body_GetCollissionGroup(const JPH_Body* body, JPH_CollisionGroup* result);
-JPH_CAPI void JPH_Body_SetCollissionGroup(JPH_Body* body, const JPH_CollisionGroup* value);
+JPH_CAPI void JPH_Body_GetCollisionGroup(const JPH_Body* body, JPH_CollisionGroup* result);
+JPH_CAPI void JPH_Body_SetCollisionGroup(JPH_Body* body, const JPH_CollisionGroup* value);
 
 JPH_CAPI bool JPH_Body_GetAllowSleeping(JPH_Body* body);
 JPH_CAPI void JPH_Body_SetAllowSleeping(JPH_Body* body, bool allowSleeping);
@@ -2743,7 +2743,7 @@ JPH_CAPI void JPH_VehicleTransmissionSettings_SetShiftDownRPM(JPH_VehicleTransmi
 JPH_CAPI float JPH_VehicleTransmissionSettings_GetClutchStrength(const JPH_VehicleTransmissionSettings* settings);
 JPH_CAPI void JPH_VehicleTransmissionSettings_SetClutchStrength(JPH_VehicleTransmissionSettings* settings, float value);
 
-/* VehicleColliionTester */
+/* VehicleCollisionTester */
 JPH_CAPI void JPH_VehicleCollisionTester_Destroy(JPH_VehicleCollisionTester* tester);
 JPH_CAPI JPH_ObjectLayer JPH_VehicleCollisionTester_GetObjectLayer(const JPH_VehicleCollisionTester* tester);
 JPH_CAPI void JPH_VehicleCollisionTester_SetObjectLayer(JPH_VehicleCollisionTester* tester, JPH_ObjectLayer value);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -196,7 +196,7 @@ static void TraceImpl(const char* fmt, ...)
 	}
 	else
 	{
-		std::cout << buffer << std::endl;
+		std::cout << buffer << '\n';
 	}
 }
 
@@ -1045,32 +1045,25 @@ static const JPH::BroadPhaseLayerFilter& ToJolt(JPH_BroadPhaseLayerFilter* bpFil
 class ManagedBroadPhaseLayerFilter final : public JPH::BroadPhaseLayerFilter
 {
 public:
-	static const JPH_BroadPhaseLayerFilter_Procs* s_Procs;
+	static inline JPH_BroadPhaseLayerFilter_Procs s_Procs{};
 	void* userData = nullptr;
 
-	ManagedBroadPhaseLayerFilter(void* userData_)
-		: userData(userData_)
-	{
-
-	}
+	ManagedBroadPhaseLayerFilter(void* userData_)	: userData(userData_)	{ }
 
 	bool ShouldCollide(BroadPhaseLayer inLayer) const override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->ShouldCollide)
+		if (s_Procs.ShouldCollide)
 		{
-			return s_Procs->ShouldCollide(userData, static_cast<JPH_BroadPhaseLayer>(inLayer));
+			return s_Procs.ShouldCollide(userData, static_cast<JPH_BroadPhaseLayer>(inLayer));
 		}
 
 		return true;
 	}
 };
 
-const JPH_BroadPhaseLayerFilter_Procs* ManagedBroadPhaseLayerFilter::s_Procs = nullptr;
-
 void JPH_BroadPhaseLayerFilter_SetProcs(const JPH_BroadPhaseLayerFilter_Procs* procs)
 {
-	ManagedBroadPhaseLayerFilter::s_Procs = procs;
+	ManagedBroadPhaseLayerFilter::s_Procs = *procs;
 }
 
 JPH_BroadPhaseLayerFilter* JPH_BroadPhaseLayerFilter_Create(void* userData)
@@ -1097,32 +1090,25 @@ static const JPH::ObjectLayerFilter& ToJolt(JPH_ObjectLayerFilter* opFilter)
 class ManagedObjectLayerFilter final : public JPH::ObjectLayerFilter
 {
 public:
-	static const JPH_ObjectLayerFilter_Procs* s_Procs;
+	static inline JPH_ObjectLayerFilter_Procs s_Procs {};
 	void* userData = nullptr;
 
-	ManagedObjectLayerFilter(void* userData_)
-		: userData(userData_)
-	{
-
-	}
+	ManagedObjectLayerFilter(void* userData_)	: userData(userData_)	{	}
 
 	bool ShouldCollide(ObjectLayer inLayer) const override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->ShouldCollide)
+		if (s_Procs.ShouldCollide)
 		{
-			return s_Procs->ShouldCollide(userData, static_cast<JPH_ObjectLayer>(inLayer));
+			return s_Procs.ShouldCollide(userData, static_cast<JPH_ObjectLayer>(inLayer));
 		}
 
 		return true;
 	}
 };
 
-const JPH_ObjectLayerFilter_Procs* ManagedObjectLayerFilter::s_Procs = nullptr;
-
 void JPH_ObjectLayerFilter_SetProcs(const JPH_ObjectLayerFilter_Procs* procs)
 {
-	ManagedObjectLayerFilter::s_Procs = procs;
+	ManagedObjectLayerFilter::s_Procs = *procs;
 }
 
 JPH_ObjectLayerFilter* JPH_ObjectLayerFilter_Create(void* userData)
@@ -1149,7 +1135,7 @@ static const JPH::BodyFilter& ToJolt(const JPH_BodyFilter* bodyFilter)
 class ManagedBodyFilter final : public JPH::BodyFilter
 {
 public:
-	static const JPH_BodyFilter_Procs* s_Procs;
+	static inline JPH_BodyFilter_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedBodyFilter(void* userData_)
@@ -1160,10 +1146,9 @@ public:
 
 	bool ShouldCollide(const BodyID& bodyID) const override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->ShouldCollide)
+		if (s_Procs.ShouldCollide)
 		{
-			return s_Procs->ShouldCollide(userData, (JPH_BodyID)bodyID.GetIndexAndSequenceNumber());
+			return s_Procs.ShouldCollide(userData, (JPH_BodyID)bodyID.GetIndexAndSequenceNumber());
 		}
 
 		return true;
@@ -1171,21 +1156,18 @@ public:
 
 	bool ShouldCollideLocked(const Body& body) const override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->ShouldCollideLocked)
+		if (s_Procs.ShouldCollideLocked)
 		{
-			return s_Procs->ShouldCollideLocked(userData, reinterpret_cast<const JPH_Body*>(&body));
+			return s_Procs.ShouldCollideLocked(userData, reinterpret_cast<const JPH_Body*>(&body));
 		}
 
 		return true;
 	}
 };
 
-const JPH_BodyFilter_Procs* ManagedBodyFilter::s_Procs = nullptr;
-
 void JPH_BodyFilter_SetProcs(const JPH_BodyFilter_Procs* procs)
 {
-	ManagedBodyFilter::s_Procs = procs;
+	ManagedBodyFilter::s_Procs = *procs;
 }
 
 JPH_BodyFilter* JPH_BodyFilter_Create(void* userData)
@@ -1212,7 +1194,7 @@ static const JPH::ShapeFilter& ToJolt(const JPH_ShapeFilter* filter)
 class ManagedShapeFilter final : public JPH::ShapeFilter
 {
 public:
-	static const JPH_ShapeFilter_Procs* s_Procs;
+	static inline JPH_ShapeFilter_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedShapeFilter(void* userData_)
@@ -1223,10 +1205,10 @@ public:
 
 	bool ShouldCollide([[maybe_unused]] const Shape* inShape2, [[maybe_unused]] const SubShapeID& inSubShapeIDOfShape2) const override
 	{
-		if (s_Procs != nullptr && s_Procs->ShouldCollide)
+		if (s_Procs.ShouldCollide)
 		{
 			auto subShapeIDOfShape2 = inSubShapeIDOfShape2.GetValue();
-			return s_Procs->ShouldCollide(userData, ToShape(inShape2), &subShapeIDOfShape2);
+			return s_Procs.ShouldCollide(userData, ToShape(inShape2), &subShapeIDOfShape2);
 		}
 
 		return true;
@@ -1238,23 +1220,21 @@ public:
 		[[maybe_unused]] const Shape* inShape2,
 		[[maybe_unused]] const SubShapeID& inSubShapeIDOfShape2) const override
 	{
-		if (s_Procs != nullptr && s_Procs->ShouldCollide2)
+		if (s_Procs.ShouldCollide2)
 		{
 			auto subShapeIDOfShape1 = inSubShapeIDOfShape1.GetValue();
 			auto subShapeIDOfShape2 = inSubShapeIDOfShape2.GetValue();
 
-			return s_Procs->ShouldCollide2(userData, ToShape(inShape1), &subShapeIDOfShape1, ToShape(inShape2), &subShapeIDOfShape2);
+			return s_Procs.ShouldCollide2(userData, ToShape(inShape1), &subShapeIDOfShape1, ToShape(inShape2), &subShapeIDOfShape2);
 		}
 
 		return true;
 	}
 };
 
-const JPH_ShapeFilter_Procs* ManagedShapeFilter::s_Procs = nullptr;
-
 void JPH_ShapeFilter_SetProcs(const JPH_ShapeFilter_Procs* procs)
 {
-	ManagedShapeFilter::s_Procs = procs;
+	ManagedShapeFilter::s_Procs = *procs;
 }
 
 JPH_ShapeFilter* JPH_ShapeFilter_Create(void* userData)
@@ -1291,7 +1271,7 @@ static const JPH::SimShapeFilter& ToJolt(const JPH_SimShapeFilter* filter)
 class ManagedSimShapeFilter final : public JPH::SimShapeFilter
 {
 public:
-	static const JPH_SimShapeFilter_Procs* s_Procs;
+	static inline JPH_SimShapeFilter_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedSimShapeFilter(void* userData_)
@@ -1308,12 +1288,12 @@ public:
 		[[maybe_unused]] const Shape* inShape2,
 		[[maybe_unused]] const SubShapeID& inSubShapeIDOfShape2) const override
 	{
-		if (s_Procs != nullptr && s_Procs->ShouldCollide)
+		if (s_Procs.ShouldCollide)
 		{
 
 			auto subShapeIDOfShape1 = inSubShapeIDOfShape1.GetValue();
 			auto subShapeIDOfShape2 = inSubShapeIDOfShape2.GetValue();
-			return s_Procs->ShouldCollide(userData,
+			return s_Procs.ShouldCollide(userData,
 				reinterpret_cast<const JPH_Body*>(&inBody1), ToShape(inShape1), &subShapeIDOfShape1,
 				reinterpret_cast<const JPH_Body*>(&inBody2), ToShape(inShape2), &subShapeIDOfShape2);
 		}
@@ -1322,11 +1302,9 @@ public:
 	}
 };
 
-const JPH_SimShapeFilter_Procs* ManagedSimShapeFilter::s_Procs = nullptr;
-
 void JPH_SimShapeFilter_SetProcs(const JPH_SimShapeFilter_Procs* procs)
 {
-	ManagedSimShapeFilter::s_Procs = procs;
+	ManagedSimShapeFilter::s_Procs = *procs;
 }
 
 JPH_SimShapeFilter* JPH_SimShapeFilter_Create(void* userData)
@@ -5219,7 +5197,7 @@ void JPH_PhysicsSystem_DrawConstraintReferenceFrame(JPH_PhysicsSystem* system, J
 class ManagedPhysicsStepListener final : public JPH::PhysicsStepListener
 {
 public:
-	static const JPH_PhysicsStepListener_Procs* s_Procs;
+	static inline JPH_PhysicsStepListener_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedPhysicsStepListener(void* userData_)
@@ -5230,24 +5208,21 @@ public:
 
 	void OnStep(const PhysicsStepListenerContext& inContext) override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->OnStep)
+		if (s_Procs.OnStep)
 		{
 			JPH_PhysicsStepListenerContext context{};
 			context.deltaTime = inContext.mDeltaTime;
 			context.isFirstStep = inContext.mIsFirstStep;
 			context.isLastStep = inContext.mIsLastStep;
 			context.physicsSystem = s_PhysicsSystems[inContext.mPhysicsSystem];
-			return s_Procs->OnStep(userData, &context);
+			return s_Procs.OnStep(userData, &context);
 		}
 	}
 };
 
-const JPH_PhysicsStepListener_Procs* ManagedPhysicsStepListener::s_Procs = nullptr;
-
 void JPH_PhysicsStepListener_SetProcs(const JPH_PhysicsStepListener_Procs* procs)
 {
-	ManagedPhysicsStepListener::s_Procs = procs;
+	ManagedPhysicsStepListener::s_Procs = *procs;
 }
 
 JPH_PhysicsStepListener* JPH_PhysicsStepListener_Create(void* userData)
@@ -5908,10 +5883,7 @@ class RayCastBodyCollectorCallback final : public RayCastBodyCollector
 {
 public:
 	RayCastBodyCollectorCallback(JPH_RayCastBodyCollectorCallback* proc_, void* userData_)
-		: proc(proc_)
-		, userData(userData_)
-	{
-	}
+		: proc(proc_), userData(userData_), _padding() { }
 
 	void AddHit(const BroadPhaseCastResult& result) override
 	{
@@ -6079,10 +6051,7 @@ class CastRayCollectorCallback final : public  JPH::CastRayCollector
 {
 public:
 	CastRayCollectorCallback(JPH_CastRayCollectorCallback* proc_, void* userData_)
-		: proc(proc_)
-		, userData(userData_)
-	{
-	}
+		: proc(proc_), userData(userData_), _padding() { }
 
 	void AddHit(const RayCastResult& result) override
 	{
@@ -7153,7 +7122,7 @@ JPH_Body* JPH_Body_GetFixedToWorldBody(void)
 class ManagedContactListener final : public JPH::ContactListener
 {
 public:
-	static const JPH_ContactListener_Procs* s_Procs;
+	static inline JPH_ContactListener_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedContactListener(void* userData_)
@@ -7168,12 +7137,11 @@ public:
 		JPH_RVec3 baseOffset;
 		FromJolt(inBaseOffset, &baseOffset);
 
-		if (s_Procs != nullptr
-			&& s_Procs->OnContactValidate)
+		if (s_Procs.OnContactValidate)
 		{
 			JPH_CollideShapeResult collideShapeResult = FromJolt(inCollisionResult);
 
-			JPH_ValidateResult result = s_Procs->OnContactValidate(
+			JPH_ValidateResult result = s_Procs.OnContactValidate(
 				userData,
 				reinterpret_cast<const JPH_Body*>(&inBody1),
 				reinterpret_cast<const JPH_Body*>(&inBody2),
@@ -7192,10 +7160,9 @@ public:
 		JPH_UNUSED(inManifold);
 		JPH_UNUSED(ioSettings);
 
-		if (s_Procs != nullptr
-			&& s_Procs->OnContactAdded)
+		if (s_Procs.OnContactAdded)
 		{
-			s_Procs->OnContactAdded(
+			s_Procs.OnContactAdded(
 				userData,
 				reinterpret_cast<const JPH_Body*>(&inBody1),
 				reinterpret_cast<const JPH_Body*>(&inBody2),
@@ -7210,10 +7177,9 @@ public:
 		JPH_UNUSED(inManifold);
 		JPH_UNUSED(ioSettings);
 
-		if (s_Procs != nullptr
-			&& s_Procs->OnContactPersisted)
+		if (s_Procs.OnContactPersisted)
 		{
-			s_Procs->OnContactPersisted(
+			s_Procs.OnContactPersisted(
 				userData,
 				reinterpret_cast<const JPH_Body*>(&inBody1),
 				reinterpret_cast<const JPH_Body*>(&inBody2),
@@ -7225,10 +7191,9 @@ public:
 
 	void OnContactRemoved(const SubShapeIDPair& inSubShapePair) override
 	{
-		if (s_Procs != nullptr
-			&& s_Procs->OnContactRemoved)
+		if (s_Procs.OnContactRemoved)
 		{
-			s_Procs->OnContactRemoved(
+			s_Procs.OnContactRemoved(
 				userData,
 				reinterpret_cast<const JPH_SubShapeIDPair*>(&inSubShapePair)
 			);
@@ -7237,11 +7202,9 @@ public:
 
 };
 
-const JPH_ContactListener_Procs* ManagedContactListener::s_Procs = nullptr;
-
 void JPH_ContactListener_SetProcs(const JPH_ContactListener_Procs* procs)
 {
-	ManagedContactListener::s_Procs = procs;
+	ManagedContactListener::s_Procs = *procs;
 }
 
 JPH_ContactListener* JPH_ContactListener_Create(void* userData)
@@ -7262,7 +7225,7 @@ void JPH_ContactListener_Destroy(JPH_ContactListener* listener)
 class ManagedBodyActivationListener final : public JPH::BodyActivationListener
 {
 public:
-	static JPH_BodyActivationListener_Procs s_Procs;
+	static inline JPH_BodyActivationListener_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedBodyActivationListener(void* userData_) : userData(userData_)	{}
@@ -8171,7 +8134,7 @@ bool JPH_CharacterVirtual_HasCollidedWithCharacter(JPH_CharacterVirtual* charact
 class ManagedCharacterContactListener final : public JPH::CharacterContactListener
 {
 public:
-	static JPH_CharacterContactListener_Procs s_Procs;
+	static inline JPH_CharacterContactListener_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedCharacterContactListener(void* userData_) 	: userData(userData_) { }
@@ -8312,7 +8275,7 @@ public:
 			settings.canPushCharacter = ioSettings.mCanPushCharacter;
 			settings.canReceiveImpulses = ioSettings.mCanReceiveImpulses;
 
-			s_Procs->OnCharacterContactAdded(
+			s_Procs.OnCharacterContactAdded(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				ToCharacterVirtual(inOtherCharacter),
@@ -8456,7 +8419,7 @@ void JPH_CharacterContactListener_Destroy(JPH_CharacterContactListener* listener
 class ManagedCharacterVsCharacterCollision final : public JPH::CharacterVsCharacterCollision
 {
 public:
-	static JPH_CharacterVsCharacterCollision_Procs s_Procs;
+	static inline JPH_CharacterVsCharacterCollision_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedCharacterVsCharacterCollision(void* userData_)
@@ -8471,7 +8434,7 @@ public:
 		RVec3Arg inBaseOffset,
 		CollideShapeCollector& ioCollector) const override
 	{
-		if (s_Procs != nullptr && s_Procs->CollideCharacter)
+		if (s_Procs.CollideCharacter)
 		{
 			JPH_RMatrix4x4 centerOfMassTransform;
 			JPH_RVec3 baseOffset;
@@ -8480,7 +8443,7 @@ public:
 			FromJolt(inCenterOfMassTransform, &centerOfMassTransform);
 			FromJolt(inBaseOffset, &baseOffset);
 
-			s_Procs->CollideCharacter(
+			s_Procs.CollideCharacter(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				&centerOfMassTransform,
@@ -8497,7 +8460,7 @@ public:
 		RVec3Arg inBaseOffset,
 		CastShapeCollector& ioCollector) const override
 	{
-		if (s_Procs != nullptr && s_Procs->CastCharacter)
+		if (s_Procs.CastCharacter)
 		{
 			JPH_RMatrix4x4 centerOfMassTransform;
 			JPH_Vec3 direction;
@@ -8508,7 +8471,7 @@ public:
 			FromJolt(inDirection, &direction);
 			FromJolt(inBaseOffset, &baseOffset);
 
-			s_Procs->CastCharacter(
+			s_Procs.CastCharacter(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				&centerOfMassTransform,
@@ -8520,11 +8483,9 @@ public:
 	}
 };
 
-const JPH_CharacterVsCharacterCollision_Procs* ManagedCharacterVsCharacterCollision::s_Procs = nullptr;
-
 void JPH_CharacterVsCharacterCollision_SetProcs(const JPH_CharacterVsCharacterCollision_Procs* procs)
 {
-	ManagedCharacterVsCharacterCollision::s_Procs = procs;
+	ManagedCharacterVsCharacterCollision::s_Procs = *procs;
 }
 
 JPH_CharacterVsCharacterCollision* JPH_CharacterVsCharacterCollision_Create(void* userData)
@@ -8640,7 +8601,7 @@ bool JPH_CollisionDispatch_CastShapeVsShapeWorldSpace(
 class ManagedBodyDrawFilter final : public JPH::BodyDrawFilter
 {
 public:
-	static const JPH_BodyDrawFilter_Procs* s_Procs;
+	static inline JPH_BodyDrawFilter_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedBodyDrawFilter(void* userData_)
@@ -8651,19 +8612,18 @@ public:
 
 	bool ShouldDraw([[maybe_unused]] const Body& inBody) const override
 	{
-		if (s_Procs != nullptr && s_Procs->ShouldDraw)
+		if (s_Procs.ShouldDraw)
 		{
-			return s_Procs->ShouldDraw(userData, reinterpret_cast<const JPH_Body*>(&inBody));
+			return s_Procs.ShouldDraw(userData, reinterpret_cast<const JPH_Body*>(&inBody));
 		}
 
 		return true;
 	}
 };
-const JPH_BodyDrawFilter_Procs* ManagedBodyDrawFilter::s_Procs = nullptr;
 
 void JPH_BodyDrawFilter_SetProcs(const JPH_BodyDrawFilter_Procs* procs)
 {
-	ManagedBodyDrawFilter::s_Procs = procs;
+	ManagedBodyDrawFilter::s_Procs = *procs;
 }
 
 JPH_BodyDrawFilter* JPH_BodyDrawFilter_Create(void* userData)
@@ -8684,7 +8644,7 @@ void JPH_BodyDrawFilter_Destroy(JPH_BodyDrawFilter* filter)
 class ManagedDebugRendererSimple final : public DebugRendererSimple
 {
 public:
-	static const JPH_DebugRenderer_Procs* s_Procs;
+	static inline JPH_DebugRenderer_Procs s_Procs{};
 	void* userData = nullptr;
 
 	ManagedDebugRendererSimple(void* userData_)
@@ -8695,20 +8655,20 @@ public:
 
 	void DrawLine(RVec3Arg inFrom, RVec3Arg inTo, ColorArg inColor) override
 	{
-		if (s_Procs != nullptr && s_Procs->DrawLine)
+		if (s_Procs.DrawLine)
 		{
 			JPH_RVec3 from, to;
 
 			FromJolt(inFrom, &from);
 			FromJolt(inTo, &to);
 
-			s_Procs->DrawLine(userData, &from, &to, inColor.GetUInt32());
+			s_Procs.DrawLine(userData, &from, &to, inColor.GetUInt32());
 		}
 	}
 
 	void DrawTriangle(RVec3Arg inV1, RVec3Arg inV2, RVec3Arg inV3, ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off) override
 	{
-		if (s_Procs != nullptr && s_Procs->DrawTriangle)
+		if (s_Procs.DrawTriangle)
 		{
 			JPH_RVec3 v1, v2, v3;
 
@@ -8716,7 +8676,7 @@ public:
 			FromJolt(inV2, &v2);
 			FromJolt(inV3, &v3);
 
-			s_Procs->DrawTriangle(userData, &v1, &v2, &v3, inColor.GetUInt32(), static_cast<JPH_DebugRenderer_CastShadow>(inCastShadow));
+			s_Procs.DrawTriangle(userData, &v1, &v2, &v3, inColor.GetUInt32(), static_cast<JPH_DebugRenderer_CastShadow>(inCastShadow));
 		}
 		else
 		{
@@ -8726,22 +8686,20 @@ public:
 
 	void DrawText3D(RVec3Arg inPosition, const string_view& inString, ColorArg inColor, float inHeight) override
 	{
-		if (s_Procs != nullptr && s_Procs->DrawText3D)
+		if (s_Procs.DrawText3D)
 		{
 			JPH_RVec3 position;
 
 			FromJolt(inPosition, &position);
 
-			s_Procs->DrawText3D(userData, &position, inString.data(), inColor.GetUInt32(), inHeight);
+			s_Procs.DrawText3D(userData, &position, inString.data(), inColor.GetUInt32(), inHeight);
 		}
 	}
 };
 
-const JPH_DebugRenderer_Procs* ManagedDebugRendererSimple::s_Procs = nullptr;
-
 void JPH_DebugRenderer_SetProcs(const JPH_DebugRenderer_Procs* procs)
 {
-	ManagedDebugRendererSimple::s_Procs = procs;
+	ManagedDebugRendererSimple::s_Procs = *procs;
 }
 
 JPH_DebugRenderer* JPH_DebugRenderer_Create(void* userData)

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -7273,7 +7273,7 @@ public:
 
 	void OnBodyActivated(const BodyID& inBodyID, uint64 inBodyUserData) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnBodyDeactivated)
+		if (s_Procs != nullptr && s_Procs->OnBodyActivated)
 		{
 			s_Procs->OnBodyActivated(
 				userData,

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -3277,12 +3277,12 @@ void JPH_BodyCreationSettings_SetObjectLayer(JPH_BodyCreationSettings* settings,
 	AsBodyCreationSettings(settings)->mObjectLayer = static_cast<JPH::ObjectLayer>(value);
 }
 
-void JPH_BodyCreationSettings_GetCollissionGroup(const JPH_BodyCreationSettings* settings, JPH_CollisionGroup* result)
+void JPH_BodyCreationSettings_GetCollisionGroup(const JPH_BodyCreationSettings* settings, JPH_CollisionGroup* result)
 {
 	FromJolt(AsBodyCreationSettings(settings)->mCollisionGroup, result);
 }
 
-void JPH_BodyCreationSettings_SetCollissionGroup(JPH_BodyCreationSettings* settings, const JPH_CollisionGroup* value)
+void JPH_BodyCreationSettings_SetCollisionGroup(JPH_BodyCreationSettings* settings, const JPH_CollisionGroup* value)
 {
 	AsBodyCreationSettings(settings)->mCollisionGroup = ToJolt(value);
 }
@@ -5483,12 +5483,12 @@ void JPH_BodyInterface_SetPositionRotationAndVelocity(JPH_BodyInterface* interfa
 	AsBodyInterface(interface)->SetPositionRotationAndVelocity(JPH::BodyID(bodyId), ToJolt(position), ToJolt(rotation), ToJolt(linearVelocity), ToJolt(angularVelocity));
 }
 
-void JPH_BodyInterface_GetCollissionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_CollisionGroup* result)
+void JPH_BodyInterface_GetCollisionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, JPH_CollisionGroup* result)
 {
 	FromJolt(AsBodyInterface(interface)->GetCollisionGroup(JPH::BodyID(bodyId)), result);
 }
 
-void JPH_BodyInterface_SetCollissionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, const JPH_CollisionGroup* group)
+void JPH_BodyInterface_SetCollisionGroup(JPH_BodyInterface* interface, JPH_BodyID bodyId, const JPH_CollisionGroup* group)
 {
 	AsBodyInterface(interface)->SetCollisionGroup(JPH::BodyID(bodyId), ToJolt(group));
 }
@@ -6898,12 +6898,12 @@ JPH_ObjectLayer JPH_Body_GetObjectLayer(const JPH_Body* body)
 	return static_cast<JPH_ObjectLayer>(AsBody(body)->GetObjectLayer());
 }
 
-void JPH_Body_GetCollissionGroup(const JPH_Body* body, JPH_CollisionGroup* result)
+void JPH_Body_GetCollisionGroup(const JPH_Body* body, JPH_CollisionGroup* result)
 {
 	FromJolt(AsBody(body)->GetCollisionGroup(), result);
 }
 
-void JPH_Body_SetCollissionGroup(JPH_Body* body, const JPH_CollisionGroup* value)
+void JPH_Body_SetCollisionGroup(JPH_Body* body, const JPH_CollisionGroup* value)
 {
 	AsBody(body)->SetCollisionGroup(ToJolt(value));
 }

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -7262,20 +7262,16 @@ void JPH_ContactListener_Destroy(JPH_ContactListener* listener)
 class ManagedBodyActivationListener final : public JPH::BodyActivationListener
 {
 public:
-	static const JPH_BodyActivationListener_Procs* s_Procs;
+	static JPH_BodyActivationListener_Procs s_Procs;
 	void* userData = nullptr;
 
-	ManagedBodyActivationListener(void* userData_)
-		: userData(userData_)
-	{
-
-	}
+	ManagedBodyActivationListener(void* userData_) : userData(userData_)	{}
 
 	void OnBodyActivated(const BodyID& inBodyID, uint64 inBodyUserData) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnBodyActivated)
+		if (s_Procs.OnBodyActivated)
 		{
-			s_Procs->OnBodyActivated(
+			s_Procs.OnBodyActivated(
 				userData,
 				inBodyID.GetIndexAndSequenceNumber(),
 				inBodyUserData
@@ -7285,9 +7281,9 @@ public:
 
 	void OnBodyDeactivated(const BodyID& inBodyID, uint64 inBodyUserData) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnBodyDeactivated)
+		if (s_Procs.OnBodyDeactivated)
 		{
-			s_Procs->OnBodyDeactivated(
+			s_Procs.OnBodyDeactivated(
 				userData,
 				inBodyID.GetIndexAndSequenceNumber(),
 				inBodyUserData
@@ -7296,11 +7292,9 @@ public:
 	}
 };
 
-const JPH_BodyActivationListener_Procs* ManagedBodyActivationListener::s_Procs = nullptr;
-
 void JPH_BodyActivationListener_SetProcs(const JPH_BodyActivationListener_Procs* procs)
 {
-	ManagedBodyActivationListener::s_Procs = procs;
+	ManagedBodyActivationListener::s_Procs = *procs;
 }
 
 JPH_BodyActivationListener* JPH_BodyActivationListener_Create(void* userData)
@@ -8177,14 +8171,10 @@ bool JPH_CharacterVirtual_HasCollidedWithCharacter(JPH_CharacterVirtual* charact
 class ManagedCharacterContactListener final : public JPH::CharacterContactListener
 {
 public:
-	static const JPH_CharacterContactListener_Procs* s_Procs;
+	static JPH_CharacterContactListener_Procs s_Procs;
 	void* userData = nullptr;
 
-	ManagedCharacterContactListener(void* userData_)
-		: userData(userData_)
-	{
-
-	}
+	ManagedCharacterContactListener(void* userData_) 	: userData(userData_) { }
 
 	void OnAdjustBodyVelocity(const CharacterVirtual* inCharacter, const Body& inBody2, Vec3& ioLinearVelocity, Vec3& ioAngularVelocity) override
 	{
@@ -8192,9 +8182,9 @@ public:
 		FromJolt(ioLinearVelocity, &linearVelocity);
 		FromJolt(ioAngularVelocity, &angularVelocity);
 
-		if (s_Procs != nullptr && s_Procs->OnAdjustBodyVelocity)
+		if (s_Procs.OnAdjustBodyVelocity)
 		{
-			s_Procs->OnAdjustBodyVelocity(
+			s_Procs.OnAdjustBodyVelocity(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				ToBody(&inBody2),
@@ -8209,9 +8199,9 @@ public:
 
 	bool OnContactValidate(const CharacterVirtual* inCharacter, const BodyID& inBodyID2, const SubShapeID& inSubShapeID2) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnContactValidate)
+		if (s_Procs.OnContactValidate)
 		{
-			return s_Procs->OnContactValidate(
+			return s_Procs.OnContactValidate(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_BodyID)inBodyID2.GetIndexAndSequenceNumber(),
@@ -8224,9 +8214,9 @@ public:
 
 	bool OnCharacterContactValidate(const CharacterVirtual* inCharacter, const CharacterVirtual* inOtherCharacter, const SubShapeID& inSubShapeID2)  override
 	{
-		if (s_Procs != nullptr && s_Procs->OnCharacterContactValidate)
+		if (s_Procs.OnCharacterContactValidate)
 		{
-			return s_Procs->OnCharacterContactValidate(
+			return s_Procs.OnCharacterContactValidate(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				ToCharacterVirtual(inOtherCharacter),
@@ -8239,7 +8229,7 @@ public:
 
 	void OnContactAdded(const CharacterVirtual* inCharacter, const BodyID& inBodyID2, const SubShapeID& inSubShapeID2, RVec3Arg inContactPosition, Vec3Arg inContactNormal, CharacterContactSettings& ioSettings) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnContactAdded)
+		if (s_Procs.OnContactAdded)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal;
@@ -8251,7 +8241,7 @@ public:
 			settings.canPushCharacter = ioSettings.mCanPushCharacter;
 			settings.canReceiveImpulses = ioSettings.mCanReceiveImpulses;
 
-			s_Procs->OnContactAdded(
+			s_Procs.OnContactAdded(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_BodyID)inBodyID2.GetIndexAndSequenceNumber(),
@@ -8268,7 +8258,7 @@ public:
 
 	void OnContactPersisted(const CharacterVirtual* inCharacter, const BodyID& inBodyID2, const SubShapeID& inSubShapeID2, RVec3Arg inContactPosition, Vec3Arg inContactNormal, CharacterContactSettings& ioSettings) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnContactPersisted)
+		if (s_Procs.OnContactPersisted)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal;
@@ -8280,7 +8270,7 @@ public:
 			settings.canPushCharacter = ioSettings.mCanPushCharacter;
 			settings.canReceiveImpulses = ioSettings.mCanReceiveImpulses;
 
-			s_Procs->OnContactPersisted(
+			s_Procs.OnContactPersisted(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_BodyID)inBodyID2.GetIndexAndSequenceNumber(),
@@ -8297,9 +8287,9 @@ public:
 
 	void OnContactRemoved(const CharacterVirtual* inCharacter, const BodyID& inBodyID2, const SubShapeID& inSubShapeID2) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnContactRemoved)
+		if (s_Procs.OnContactRemoved)
 		{
-			s_Procs->OnContactRemoved(
+			s_Procs.OnContactRemoved(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_BodyID)inBodyID2.GetIndexAndSequenceNumber(),
@@ -8310,7 +8300,7 @@ public:
 
 	void OnCharacterContactAdded(const CharacterVirtual* inCharacter, const CharacterVirtual* inOtherCharacter, const SubShapeID& inSubShapeID2, RVec3Arg inContactPosition, Vec3Arg inContactNormal, CharacterContactSettings& ioSettings) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnCharacterContactAdded)
+		if (s_Procs.OnCharacterContactAdded)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal;
@@ -8339,7 +8329,7 @@ public:
 
 	void OnCharacterContactPersisted(const CharacterVirtual* inCharacter, const CharacterVirtual* inOtherCharacter, const SubShapeID& inSubShapeID2, RVec3Arg inContactPosition, Vec3Arg inContactNormal, CharacterContactSettings& ioSettings) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnCharacterContactPersisted)
+		if (s_Procs.OnCharacterContactPersisted)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal;
@@ -8351,7 +8341,7 @@ public:
 			settings.canPushCharacter = ioSettings.mCanPushCharacter;
 			settings.canReceiveImpulses = ioSettings.mCanReceiveImpulses;
 
-			s_Procs->OnCharacterContactPersisted(
+			s_Procs.OnCharacterContactPersisted(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				ToCharacterVirtual(inOtherCharacter),
@@ -8368,9 +8358,9 @@ public:
 
 	void OnCharacterContactRemoved(const CharacterVirtual* inCharacter, const CharacterID& inOtherCharacterID, const SubShapeID& inSubShapeID2) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnCharacterContactRemoved)
+		if (s_Procs.OnCharacterContactRemoved)
 		{
-			s_Procs->OnCharacterContactRemoved(
+			s_Procs.OnCharacterContactRemoved(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_CharacterID)inOtherCharacterID.GetValue(),
@@ -8384,7 +8374,7 @@ public:
 		const PhysicsMaterial* inContactMaterial, Vec3Arg inCharacterVelocity,
 		Vec3& ioNewCharacterVelocity) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnContactSolve)
+		if (s_Procs.OnContactSolve)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal, contactVelocity, characterVelocity, newCharacterVelocity;
@@ -8395,7 +8385,7 @@ public:
 			FromJolt(inCharacterVelocity, &characterVelocity);
 			FromJolt(ioNewCharacterVelocity, &newCharacterVelocity);
 
-			s_Procs->OnContactSolve(
+			s_Procs.OnContactSolve(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				(JPH_BodyID)inBodyID2.GetIndexAndSequenceNumber(),
@@ -8414,7 +8404,7 @@ public:
 
 	void OnCharacterContactSolve(const CharacterVirtual* inCharacter, const CharacterVirtual* inOtherCharacter, const SubShapeID& inSubShapeID2, RVec3Arg inContactPosition, Vec3Arg inContactNormal, Vec3Arg inContactVelocity, const PhysicsMaterial* inContactMaterial, Vec3Arg inCharacterVelocity, Vec3& ioNewCharacterVelocity) override
 	{
-		if (s_Procs != nullptr && s_Procs->OnCharacterContactSolve)
+		if (s_Procs.OnCharacterContactSolve)
 		{
 			JPH_RVec3 contactPosition;
 			JPH_Vec3 contactNormal, contactVelocity, characterVelocity, newCharacterVelocity;
@@ -8425,7 +8415,7 @@ public:
 			FromJolt(inCharacterVelocity, &characterVelocity);
 			FromJolt(ioNewCharacterVelocity, &newCharacterVelocity);
 
-			s_Procs->OnCharacterContactSolve(
+			s_Procs.OnCharacterContactSolve(
 				userData,
 				ToCharacterVirtual(inCharacter),
 				ToCharacterVirtual(inOtherCharacter),
@@ -8443,11 +8433,9 @@ public:
 	}
 };
 
-const JPH_CharacterContactListener_Procs* ManagedCharacterContactListener::s_Procs = nullptr;
-
 void JPH_CharacterContactListener_SetProcs(const JPH_CharacterContactListener_Procs* procs)
 {
-	ManagedCharacterContactListener::s_Procs = procs;
+	ManagedCharacterContactListener::s_Procs = *procs;
 }
 
 JPH_CharacterContactListener* JPH_CharacterContactListener_Create(void* userData)
@@ -8468,7 +8456,7 @@ void JPH_CharacterContactListener_Destroy(JPH_CharacterContactListener* listener
 class ManagedCharacterVsCharacterCollision final : public JPH::CharacterVsCharacterCollision
 {
 public:
-	static const JPH_CharacterVsCharacterCollision_Procs* s_Procs;
+	static JPH_CharacterVsCharacterCollision_Procs s_Procs;
 	void* userData = nullptr;
 
 	ManagedCharacterVsCharacterCollision(void* userData_)


### PR DESCRIPTION
A native pointer pointing a managed static struct field is unsafe, easy to cause crash, e.g. after domain reload. Now no need for maintain the func pointer struct.