### PR TITLE
Change CI to use Ubuntu 22.04 for better compatibility with older systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         path: bin
 
   linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v5
 


### PR DESCRIPTION
Changes CI to use Ubuntu 22.04.

PR created to ensure workflow works as expected.