### PR TITLE
Strip release builds for linux and android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Install dependencies on Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu llvm
 
     # Linux
     - name: CMake Configure (linux-x64)
@@ -216,6 +216,11 @@ jobs:
         mv build_android_arm64_v8a/lib/libjoltcd.so bin/android-arm64/libjoltcd.so
         mv build_android_armeabi_v7a/lib/libjoltcd.so bin/android-arm/libjoltcd.so
         mv build_android_x86_64/lib/libjoltcd.so bin/android-x64/libjoltcd.so
+        llvm-strip --strip-unneeded bin/linux-x64/libjoltc.so
+        llvm-strip --strip-unneeded bin/linux-arm64/libjoltc.so
+        llvm-strip --strip-unneeded bin/android-arm/libjoltc.so
+        llvm-strip --strip-unneeded bin/android-arm64/libjoltc.so
+        llvm-strip --strip-unneeded bin/android-x64/libjoltc.so
     - uses: actions/upload-artifact@v4
       with:
         name: libs_linux


### PR DESCRIPTION
# Strip release builds for linux and android

Linux and Android builds (Android especially) get massive even when built in release mode, due to unnecessary symbols. This PR adds stripping for release builds only.

For example, last time I manually built joltc, after stripping it was only 2.45MB:

<img width="363" height="509" alt="image" src="https://github.com/user-attachments/assets/4d782267-7f00-44a5-ac45-55ba652f91ea" />

Without stripping, right now, you'll notice the release version on Android is 28MB while the debug version is 32.8MB

I believe this would be a big improvement especially on android, but I'm happy to do any changes you think should be done, or I can keep stripping on my side manually. I think it'd be good for wider adoptability of Jolt in general if the binaries were smaller though.

Please let me know if you'd like any changes, and thanks a lot for your work!