### PR TITLE
Added JPH_WheeledVehicleController_SetTireMaxImpulseCallback

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -989,6 +989,9 @@ typedef struct JPH_JobSystemConfig {
 
 typedef struct JPH_JobSystem JPH_JobSystem;
 
+/* (uint32_t wheelIndex, float &longitudinalImpulse, float &lateralImpulse, float suspensionImpulse, float longitudinalFriction, float lateralFriction, float longitudinalSlip, float lateralSlip, float deltaTime) */
+typedef void (JPH_API_CALL *JPH_TireMaxImpulseCallback)(uint32_t ,float* ,float* ,float ,float ,float ,float ,float ,float );
+
 JPH_CAPI JPH_JobSystem* JPH_JobSystemThreadPool_Create(const JobSystemThreadPoolConfig* config);
 JPH_CAPI JPH_JobSystem* JPH_JobSystemCallback_Create(const JPH_JobSystemConfig* config);
 JPH_CAPI void JPH_JobSystem_Destroy(JPH_JobSystem* jobSystem);
@@ -2829,6 +2832,7 @@ JPH_CAPI float JPH_WheeledVehicleController_GetBrakeInput(const JPH_WheeledVehic
 JPH_CAPI void JPH_WheeledVehicleController_SetHandBrakeInput(JPH_WheeledVehicleController* controller, float handBrakeInput);
 JPH_CAPI float JPH_WheeledVehicleController_GetHandBrakeInput(const JPH_WheeledVehicleController* controller);
 JPH_CAPI float JPH_WheeledVehicleController_GetWheelSpeedAtClutch(const JPH_WheeledVehicleController* controller);
+JPH_CAPI void JPH_WheeledVehicleController_SetTireMaxImpulseCallback(JPH_WheeledVehicleController* controller, JPH_TireMaxImpulseCallback tireMaxImpulseCallback);
 
 /* WheelSettingsTV - WheelTV - TrackedVehicleController */
 /* TODO: Add VehicleTrack and VehicleTrackSettings */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -10274,6 +10274,30 @@ float JPH_WheeledVehicleController_GetWheelSpeedAtClutch(const JPH_WheeledVehicl
 	return AsWheeledVehicleController(controller)->GetWheelSpeedAtClutch();
 }
 
+void JPH_WheeledVehicleController_SetTireMaxImpulseCallback(JPH_WheeledVehicleController *controller, JPH_TireMaxImpulseCallback tireMaxImpulseCallback) {
+	AsWheeledVehicleController(controller)->SetTireMaxImpulseCallback([tireMaxImpulseCallback](
+		int wheelIndex,
+		float &outLongitudinalImpulse,
+		float &outLateralImpulse,
+		float inSuspensionImpulse,
+		float inLongitudinalFriction,
+		float inLateralFriction,
+		float inLongitudinalSlip,
+		float inLateralSlip,
+		float deltaTime){
+			tireMaxImpulseCallback(
+				static_cast<uint32_t>(wheelIndex),
+				&outLongitudinalImpulse,
+				&outLateralImpulse,
+				inSuspensionImpulse,
+				inLongitudinalFriction,
+				inLateralFriction,
+				inLongitudinalSlip,
+				inLateralSlip,
+				deltaTime);
+		});
+}
+
 /* WheelSettingsTV - WheelTV - TrackedVehicleController */
 JPH_WheelSettingsTV* JPH_WheelSettingsTV_Create(void)
 {


### PR DESCRIPTION
Adding JPH_WheeledVehicleController_SetTireMaxImpulseCallback. 

This is to allow specifying custom longitudinal and lateral impulses to wheeled vehicles. 

From the Jolt Physics Vehicle Sample:
```C++
// The vehicle settings were tweaked with a buggy implementation of the longitudinal tire impulses, this meant that PhysicsSettings::mNumVelocitySteps times more impulse
// could be applied than intended. To keep the behavior of the vehicle the same we increase the max longitudinal impulse by the same factor. In a future version the vehicle
// will be retweaked.
static_cast<WheeledVehicleController *>(mVehicleConstraint->GetController())->SetTireMaxImpulseCallback([](uint, float &outLongitudinalImpulse, float &outLateralImpulse, float inSuspensionImpulse, float inLongitudinalFriction, float inLateralFriction, float, float, float)
{
	outLongitudinalImpulse = 10.0f * inLongitudinalFriction * inSuspensionImpulse;
	outLateralImpulse = inLateralFriction * inSuspensionImpulse;
});
```