### PR TITLE
Feat/vehicle engine settings update

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2655,7 +2655,7 @@ typedef struct JPH_VehicleEngineSettings {
 	float					maxTorque;
 	float					minRPM;
 	float					maxRPM;
-	//LinearCurve			normalizedTorque;
+	const JPH_LinearCurve*	normalizedTorque;
 	float					inertia;
 	float					angularDamping;
 } JPH_VehicleEngineSettings;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -9615,6 +9615,17 @@ void JPH_VehicleEngineSettings_Init(JPH_VehicleEngineSettings* settings)
 	settings->maxRPM = joltSettings.mMaxRPM;
 	settings->inertia = joltSettings.mInertia;
 	settings->angularDamping = joltSettings.mAngularDamping;
+
+	// Copy default normalized torque to JPH_VehicleEngineSettings->normalizedTorque
+	auto joltNormalizedTorque = joltSettings.mNormalizedTorque;
+	auto pointCount = joltNormalizedTorque.mPoints.size();
+	auto normalizedTorque = JPH_LinearCurve_Create();
+	JPH_LinearCurve_Reserve(normalizedTorque, pointCount);
+	for (int i = 0; i < pointCount; ++i) {
+		auto point = joltNormalizedTorque.mPoints[i];
+		JPH_LinearCurve_AddPoint(normalizedTorque, point.mX, point.mY);
+	}
+	settings->normalizedTorque = normalizedTorque;
 }
 
 static void JPH_VehicleEngineSettings_FromJolt(JPH_VehicleEngineSettings* settings, const VehicleEngineSettings& joltSettings)
@@ -9626,6 +9637,7 @@ static void JPH_VehicleEngineSettings_FromJolt(JPH_VehicleEngineSettings* settin
 	settings->maxRPM = joltSettings.mMaxRPM;
 	settings->inertia = joltSettings.mInertia;
 	settings->angularDamping = joltSettings.mAngularDamping;
+	settings->normalizedTorque = ToLinearCurve(&joltSettings.mNormalizedTorque);
 }
 
 static void JPH_VehicleEngineSettings_ToJolt(VehicleEngineSettings* joltSettings, const JPH_VehicleEngineSettings* settings)
@@ -9638,6 +9650,7 @@ static void JPH_VehicleEngineSettings_ToJolt(VehicleEngineSettings* joltSettings
 	joltSettings->mMaxRPM = settings->maxRPM;
 	joltSettings->mInertia = settings->inertia;
 	joltSettings->mAngularDamping = settings->angularDamping;
+	joltSettings->mNormalizedTorque = AsLinearCurve(*settings->normalizedTorque);
 }
 
 /* VehicleEngine */


### PR DESCRIPTION
As per discussion. This PR just adds the LinearCurve normalized torque pointer to the JPH_VehicleEngineSettings. The Init function copies the data over to the JPH_VehicleEngineSettings as the linear curve data of JPH::VehicleEngineSettings.normalizedTorque goes out of scope at the end of Init.