### PR TITLE
Add soft body support, direct memory access APIs, and TSan compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,25 +141,32 @@ if (JPH_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
 endif ()
 
 # Search for local JoltPhysics first
-if(EXISTS "${CMAKE_SOURCE_DIR}/JoltPhysics/Build/CMakeLists.txt")
-    message(STATUS "Using local JoltPhysics from ${CMAKE_SOURCE_DIR}/JoltPhysics")
-
+if (DEFINED JOLT_PHYSICS_ROOT AND EXISTS "${JOLT_PHYSICS_ROOT}/Build/CMakeLists.txt")
+    message(STATUS "[JoltC] Using provided JOLT_PHYSICS_ROOT: ${JOLT_PHYSICS_ROOT}")
     FetchContent_Declare(
         JoltPhysics
-        SOURCE_DIR "${CMAKE_SOURCE_DIR}/JoltPhysics"
+        SOURCE_DIR "${JOLT_PHYSICS_ROOT}"
         SOURCE_SUBDIR "Build"
     )
-elseif(EXISTS "${CMAKE_SOURCE_DIR}/../JoltPhysics/Build/CMakeLists.txt")
-    message(STATUS "Using local JoltPhysics from ${CMAKE_SOURCE_DIR}/../JoltPhysics")
-
+# 2. Check for JoltPhysics nested inside JoltC
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/JoltPhysics/Build/CMakeLists.txt")
+    message(STATUS "[JoltC] Using local JoltPhysics from nested directory")
     FetchContent_Declare(
         JoltPhysics
-        SOURCE_DIR "${CMAKE_SOURCE_DIR}/../JoltPhysics"
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/JoltPhysics"
         SOURCE_SUBDIR "Build"
     )
+# 3. Check for JoltPhysics side-by-side with JoltC
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../JoltPhysics/Build/CMakeLists.txt")
+    message(STATUS "[JoltC] Using local JoltPhysics from side-by-side directory")
+    FetchContent_Declare(
+        JoltPhysics
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../JoltPhysics"
+        SOURCE_SUBDIR "Build"
+    )
+# 4. Fallback to GitHub
 else()
-    message(STATUS "Local Jolt not found, download from remote")
-
+    message(STATUS "[JoltC] Local Jolt not found, downloading from GitHub v5.5.0")
     FetchContent_Declare(
         JoltPhysics
         GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"
@@ -167,6 +174,7 @@ else()
         SOURCE_SUBDIR "Build"
     )
 endif()
+
 FetchContent_MakeAvailable(JoltPhysics)
 
 if (XCODE)

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2993,6 +2993,7 @@ JPH_CAPI void JPH_TrackedVehicleControllerSettings_GetEngine(const JPH_TrackedVe
 JPH_CAPI void JPH_TrackedVehicleControllerSettings_SetEngine(JPH_TrackedVehicleControllerSettings* settings, const JPH_VehicleEngineSettings* value);
 JPH_CAPI const JPH_VehicleTransmissionSettings* JPH_TrackedVehicleControllerSettings_GetTransmission(const JPH_TrackedVehicleControllerSettings* settings);
 JPH_CAPI void JPH_TrackedVehicleControllerSettings_SetTransmission(JPH_TrackedVehicleControllerSettings* settings, const JPH_VehicleTransmissionSettings* value);
+JPH_CAPI void JPH_TrackedVehicleControllerSettings_SetTrack(JPH_TrackedVehicleControllerSettings* settings, uint32_t index, const JPH_VehicleTrackSettings* track);
 
 JPH_CAPI void JPH_TrackedVehicleController_SetDriverInput(JPH_TrackedVehicleController* controller, float forward, float leftRatio, float rightRatio, float brake);
 JPH_CAPI float JPH_TrackedVehicleController_GetForwardInput(const JPH_TrackedVehicleController* controller);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2868,6 +2868,7 @@ JPH_CAPI float JPH_VehicleTransmissionSettings_GetClutchStrength(const JPH_Vehic
 JPH_CAPI void JPH_VehicleTransmissionSettings_SetClutchStrength(JPH_VehicleTransmissionSettings* settings, float value);
 
 /* VehicleTransmission */
+JPH_CAPI void JPH_VehicleTransmission_SetMode(JPH_VehicleTransmission* transmission, JPH_TransmissionMode mode);
 JPH_CAPI void JPH_VehicleTransmission_Set(JPH_VehicleTransmission* transmission, int currentGear, float clutchFriction);
 JPH_CAPI void JPH_VehicleTransmission_Update(JPH_VehicleTransmission* transmission, float deltaTime, float currentRPM, float forwardInput, bool canShiftUp);
 JPH_CAPI int JPH_VehicleTransmission_GetCurrentGear(const JPH_VehicleTransmission* transmission);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -2924,6 +2924,8 @@ JPH_CAPI void JPH_WheeledVehicleControllerSettings_GetDifferential(const JPH_Whe
 JPH_CAPI void JPH_WheeledVehicleControllerSettings_SetDifferential(JPH_WheeledVehicleControllerSettings* settings, uint32_t index, const JPH_VehicleDifferentialSettings* value);
 JPH_CAPI void JPH_WheeledVehicleControllerSettings_SetDifferentials(JPH_WheeledVehicleControllerSettings* settings, const JPH_VehicleDifferentialSettings* values, uint32_t count);
 
+JPH_CAPI void JPH_WheeledVehicleControllerSettings_AddDifferential(JPH_WheeledVehicleControllerSettings* settings, int leftWheel, int rightWheel);
+
 JPH_CAPI float JPH_WheeledVehicleControllerSettings_GetDifferentialLimitedSlipRatio(const JPH_WheeledVehicleControllerSettings* settings);
 JPH_CAPI void JPH_WheeledVehicleControllerSettings_SetDifferentialLimitedSlipRatio(JPH_WheeledVehicleControllerSettings* settings, float value);
 

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -474,6 +474,7 @@ typedef struct JPH_RVec3 {
 	double x;
 	double y;
 	double z;
+	double _padding; // Add this to match Jolt 5.0+ 32-byte alignment
 } JPH_RVec3;
 
 typedef struct JPH_RMat4 {

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1125,6 +1125,7 @@ JPH_CAPI uint32_t JPH_PhysicsSystem_GetMaxBodies(const JPH_PhysicsSystem* system
 JPH_CAPI uint32_t JPH_PhysicsSystem_GetNumConstraints(const JPH_PhysicsSystem* system);
 
 JPH_CAPI void JPH_PhysicsSystem_GetActiveBodies(const JPH_PhysicsSystem* system, JPH_BodyID* ids, uint32_t count);
+JPH_CAPI const JPH_BodyID* JPH_PhysicsSystem_GetActiveBodiesUnsafe(const JPH_PhysicsSystem* system, JPH_BodyType type);
 
 JPH_CAPI void JPH_PhysicsSystem_SetGravity(JPH_PhysicsSystem* system, const JPH_Vec3* value);
 JPH_CAPI void JPH_PhysicsSystem_GetGravity(JPH_PhysicsSystem* system, JPH_Vec3* result);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -474,7 +474,6 @@ typedef struct JPH_RVec3 {
 	double x;
 	double y;
 	double z;
-	double _padding; // Add this to match Jolt 5.0+ 32-byte alignment
 } JPH_RVec3;
 
 typedef struct JPH_RMat4 {

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1788,6 +1788,7 @@ JPH_CAPI void JPH_BodyInterface_RemoveBody(JPH_BodyInterface* bodyInterface, JPH
 JPH_CAPI void JPH_BodyInterface_RemoveAndDestroyBody(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID);
 JPH_CAPI bool JPH_BodyInterface_IsAdded(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID);
 JPH_CAPI JPH_BodyType JPH_BodyInterface_GetBodyType(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID);
+JPH_CAPI const JPH_Body* JPH_PhysicsSystem_GetBodyPtr(const JPH_PhysicsSystem* system, JPH_BodyID bodyID);
 
 JPH_CAPI void JPH_BodyInterface_SetLinearVelocity(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID, const JPH_Vec3* velocity);
 JPH_CAPI void JPH_BodyInterface_GetLinearVelocity(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID, JPH_Vec3* velocity);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1124,6 +1124,8 @@ JPH_CAPI uint32_t JPH_PhysicsSystem_GetNumActiveBodies(const JPH_PhysicsSystem* 
 JPH_CAPI uint32_t JPH_PhysicsSystem_GetMaxBodies(const JPH_PhysicsSystem* system);
 JPH_CAPI uint32_t JPH_PhysicsSystem_GetNumConstraints(const JPH_PhysicsSystem* system);
 
+JPH_CAPI void JPH_PhysicsSystem_GetActiveBodies(const JPH_PhysicsSystem* system, JPH_BodyID* ids, uint32_t count);
+
 JPH_CAPI void JPH_PhysicsSystem_SetGravity(JPH_PhysicsSystem* system, const JPH_Vec3* value);
 JPH_CAPI void JPH_PhysicsSystem_GetGravity(JPH_PhysicsSystem* system, JPH_Vec3* result);
 

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -125,6 +125,7 @@ typedef struct JPH_EmptyShape							JPH_EmptyShape;
 
 typedef struct JPH_BodyCreationSettings					JPH_BodyCreationSettings;
 typedef struct JPH_SoftBodyCreationSettings				JPH_SoftBodyCreationSettings;
+typedef struct JPH_SoftBodySharedSettings 				JPH_SoftBodySharedSettings;
 typedef struct JPH_BodyInterface						JPH_BodyInterface;
 typedef struct JPH_BodyLockInterface					JPH_BodyLockInterface;
 typedef struct JPH_BroadPhaseQuery						JPH_BroadPhaseQuery;
@@ -1588,9 +1589,17 @@ JPH_CAPI void JPH_BodyCreationSettings_SetInertiaMultiplier(JPH_BodyCreationSett
 JPH_CAPI void JPH_BodyCreationSettings_GetMassPropertiesOverride(const JPH_BodyCreationSettings* settings, JPH_MassProperties* result);
 JPH_CAPI void JPH_BodyCreationSettings_SetMassPropertiesOverride(JPH_BodyCreationSettings* settings, const JPH_MassProperties* massProperties);
 
+/* JPH_SoftBodySharedSettings */
+JPH_CAPI JPH_SoftBodySharedSettings* JPH_SoftBodySharedSettings_Create(void);
+JPH_CAPI void JPH_SoftBodySharedSettings_Destroy(JPH_SoftBodySharedSettings* settings);
+JPH_CAPI void JPH_SoftBodySharedSettings_AddVertex(JPH_SoftBodySharedSettings* settings, const JPH_Vec3* position, float invMass);
+JPH_CAPI void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, uint32_t vertex1, uint32_t vertex2, uint32_t vertex3);
+JPH_CAPI void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings);
+
 /* JPH_SoftBodyCreationSettings */
 JPH_CAPI JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void);
 JPH_CAPI void JPH_SoftBodyCreationSettings_Destroy(JPH_SoftBodyCreationSettings* settings);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetSharedSettings(JPH_SoftBodyCreationSettings* settings, const JPH_SoftBodySharedSettings* sharedSettings);
 
 /* JPH_Constraint */
 JPH_CAPI void JPH_Constraint_Destroy(JPH_Constraint* constraint);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1227,6 +1227,8 @@ JPH_CAPI void JPH_Vec3_MultiplyMatrix(const JPH_Mat4* left, const JPH_Vec3* righ
 JPH_CAPI void JPH_Vec3_Divide(const JPH_Vec3* v1, const JPH_Vec3* v2, JPH_Vec3* result);
 JPH_CAPI void JPH_Vec3_DivideScalar(const JPH_Vec3* v, float scalar, JPH_Vec3* result);
 
+JPH_CAPI void JPH_Vec3_GetNormalizedPerpendicular(const JPH_Vec3* v, JPH_Vec3* result);
+
 JPH_CAPI void JPH_Mat4_Add(const JPH_Mat4* m1, const JPH_Mat4* m2, JPH_Mat4* result);
 JPH_CAPI void JPH_Mat4_Subtract(const JPH_Mat4* m1, const JPH_Mat4* m2, JPH_Mat4* result);
 JPH_CAPI void JPH_Mat4_Multiply(const JPH_Mat4* m1, const JPH_Mat4* m2, JPH_Mat4* result);

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -391,6 +391,13 @@ typedef enum JPH_SoftBodyConstraintColor
 	_JPH_SoftBodyConstraintColor_Force32 = 0x7FFFFFFF
 } JPH_SoftBodyConstraintColor;
 
+typedef enum JPH_SoftBodyBendType 
+{
+    JPH_SoftBodyBendType_None,
+    JPH_SoftBodyBendType_Distance,
+    JPH_SoftBodyBendType_Dihedral
+} JPH_SoftBodyBendType;
+
 typedef enum JPH_BodyManager_ShapeColor
 {
 	JPH_BodyManager_ShapeColor_InstanceColor,				///< Random color per instance
@@ -1594,7 +1601,13 @@ JPH_CAPI JPH_SoftBodySharedSettings* JPH_SoftBodySharedSettings_Create(void);
 JPH_CAPI void JPH_SoftBodySharedSettings_Destroy(JPH_SoftBodySharedSettings* settings);
 JPH_CAPI void JPH_SoftBodySharedSettings_AddVertex(JPH_SoftBodySharedSettings* settings, const JPH_Vec3* position, float invMass);
 JPH_CAPI void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, uint32_t vertex1, uint32_t vertex2, uint32_t vertex3);
+JPH_CAPI void JPH_SoftBodySharedSettings_CreateConstraints(JPH_SoftBodySharedSettings* settings, float compliance, JPH_SoftBodyBendType bendType);
 JPH_CAPI void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings);
+/* NOTE: Must be called BEFORE CreateConstraints for correct mass-participation math. */
+JPH_CAPI void JPH_SoftBodySharedSettings_AddPinnedVertex(JPH_SoftBodySharedSettings* settings, uint32_t index);
+JPH_CAPI uint32_t JPH_SoftBodySharedSettings_GetVertexCount(const JPH_SoftBodySharedSettings* settings);
+/* Vertex data access (verification/retrieval) */
+JPH_CAPI void JPH_SoftBodySharedSettings_GetVertexPosition(const JPH_SoftBodySharedSettings* settings, uint32_t index, JPH_Vec3* outPos);
 
 /* JPH_SoftBodyCreationSettings */
 JPH_CAPI JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void);
@@ -1608,6 +1621,17 @@ JPH_CAPI void JPH_SoftBodyCreationSettings_SetPosition(JPH_SoftBodyCreationSetti
 JPH_CAPI void JPH_SoftBodyCreationSettings_SetRotation(JPH_SoftBodyCreationSettings* settings, const JPH_Quat* value);
 JPH_CAPI void JPH_SoftBodyCreationSettings_SetObjectLayer(JPH_SoftBodyCreationSettings* settings, JPH_ObjectLayer value);
 JPH_CAPI void JPH_SoftBodyCreationSettings_SetAllowSleeping(JPH_SoftBodyCreationSettings* settings, bool value);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetPressure(JPH_SoftBodyCreationSettings* settings, float pressure);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetLinearDamping(JPH_SoftBodyCreationSettings* settings, float damping);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetNumIterations(JPH_SoftBodyCreationSettings* settings, uint32_t iterations);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetMaxLinearVelocity(JPH_SoftBodyCreationSettings* settings, float max_vel);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetGravityFactor(JPH_SoftBodyCreationSettings* settings, float gravityFactor);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetFriction(JPH_SoftBodyCreationSettings* settings, float friction);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetRestitution(JPH_SoftBodyCreationSettings* settings, float restitution);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetMakeRotationIdentity(JPH_SoftBodyCreationSettings* settings, bool value);
+JPH_CAPI float JPH_SoftBodyCreationSettings_GetVertexRadius(const JPH_SoftBodyCreationSettings* settings);
+JPH_CAPI bool JPH_SoftBodyCreationSettings_GetMakeRotationIdentity(const JPH_SoftBodyCreationSettings* settings);
+
 
 /* JPH_Constraint */
 JPH_CAPI void JPH_Constraint_Destroy(JPH_Constraint* constraint);
@@ -2177,6 +2201,9 @@ JPH_CAPI void JPH_Body_SetUserData(JPH_Body* body, uint64_t userData);
 JPH_CAPI uint64_t JPH_Body_GetUserData(JPH_Body* body);
 
 JPH_CAPI JPH_Body* JPH_Body_GetFixedToWorldBody(void);
+
+JPH_CAPI uint32_t JPH_Body_GetSoftBodyVertexCount(const JPH_Body* body);
+JPH_CAPI void     JPH_Body_GetSoftBodyVertexPosition(const JPH_Body* body, uint32_t index, JPH_Vec3* outPos);
 
 /* JPH_BroadPhaseLayerFilter_Procs */
 typedef struct JPH_BroadPhaseLayerFilter_Procs {

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1608,6 +1608,15 @@ JPH_CAPI void JPH_SoftBodySharedSettings_AddPinnedVertex(JPH_SoftBodySharedSetti
 JPH_CAPI uint32_t JPH_SoftBodySharedSettings_GetVertexCount(const JPH_SoftBodySharedSettings* settings);
 /* Vertex data access (verification/retrieval) */
 JPH_CAPI void JPH_SoftBodySharedSettings_GetVertexPosition(const JPH_SoftBodySharedSettings* settings, uint32_t index, JPH_Vec3* outPos);
+JPH_CAPI void JPH_SoftBodySharedSettings_AddVertices(
+    JPH_SoftBodySharedSettings* settings,
+    const JPH_Vec3* positions,
+    const float* invMasses,
+    uint32_t count);
+JPH_CAPI void JPH_SoftBodySharedSettings_AddFaces(
+    JPH_SoftBodySharedSettings* settings,
+    const uint32_t* indices,
+    uint32_t face_count);
 
 /* JPH_SoftBodyCreationSettings */
 JPH_CAPI JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void);
@@ -2204,6 +2213,7 @@ JPH_CAPI JPH_Body* JPH_Body_GetFixedToWorldBody(void);
 
 JPH_CAPI uint32_t JPH_Body_GetSoftBodyVertexCount(const JPH_Body* body);
 JPH_CAPI void     JPH_Body_GetSoftBodyVertexPosition(const JPH_Body* body, uint32_t index, JPH_Vec3* outPos);
+JPH_CAPI void 	  JPH_Body_GetSoftBodyVertexPositions(const JPH_Body* body, JPH_Vec3* outPositions, uint32_t* outCount);
 
 /* JPH_BroadPhaseLayerFilter_Procs */
 typedef struct JPH_BroadPhaseLayerFilter_Procs {

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1049,6 +1049,9 @@ JPH_CAPI JPH_ObjectVsBroadPhaseLayerFilter* JPH_ObjectVsBroadPhaseLayerFilterMas
 JPH_CAPI JPH_ObjectVsBroadPhaseLayerFilter* JPH_ObjectVsBroadPhaseLayerFilterTable_Create(
 	JPH_BroadPhaseLayerInterface* broadPhaseLayerInterface, uint32_t numBroadPhaseLayers,
 	JPH_ObjectLayerPairFilter* objectLayerPairFilter, uint32_t numObjectLayers);
+JPH_CAPI void JPH_BroadPhaseLayerInterfaceTable_Destroy(JPH_BroadPhaseLayerInterface* bpInterface);
+JPH_CAPI void JPH_ObjectLayerPairFilterTable_Destroy(JPH_ObjectLayerPairFilter* filter);
+JPH_CAPI void JPH_ObjectVsBroadPhaseLayerFilterTable_Destroy(JPH_ObjectVsBroadPhaseLayerFilter* filter);
 
 JPH_CAPI void JPH_DrawSettings_InitDefault(JPH_DrawSettings* settings);
 

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -1600,6 +1600,14 @@ JPH_CAPI void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* se
 JPH_CAPI JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void);
 JPH_CAPI void JPH_SoftBodyCreationSettings_Destroy(JPH_SoftBodyCreationSettings* settings);
 JPH_CAPI void JPH_SoftBodyCreationSettings_SetSharedSettings(JPH_SoftBodyCreationSettings* settings, const JPH_SoftBodySharedSettings* sharedSettings);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetVertexRadius(JPH_SoftBodyCreationSettings* settings, float radius);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetUserData(JPH_SoftBodyCreationSettings* settings, uint64_t userData);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetCollisionGroup(JPH_SoftBodyCreationSettings* settings, const JPH_CollisionGroup* group);
+
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetPosition(JPH_SoftBodyCreationSettings* settings, const JPH_RVec3* value);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetRotation(JPH_SoftBodyCreationSettings* settings, const JPH_Quat* value);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetObjectLayer(JPH_SoftBodyCreationSettings* settings, JPH_ObjectLayer value);
+JPH_CAPI void JPH_SoftBodyCreationSettings_SetAllowSleeping(JPH_SoftBodyCreationSettings* settings, bool value);
 
 /* JPH_Constraint */
 JPH_CAPI void JPH_Constraint_Destroy(JPH_Constraint* constraint);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -760,7 +760,7 @@ bool JPH_Init()
 	if (s_initialized)
 		return true;
 
-	printf("[Culverin-Internal] JoltC Fork Loaded with TempAllocatorMalloc\n");
+	std::cout << ">>> [CULVERIN] LOADING PATCHED JOLTC (MALLOC ALLOCATOR) <<<" << std::endl;
 
 	JPH::RegisterDefaultAllocator();
 

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -5275,6 +5275,12 @@ JPH_CAPI void JPH_PhysicsSystem_GetActiveBodies(const JPH_PhysicsSystem* system,
 	}
 }
 
+JPH_CAPI const JPH_BodyID* JPH_PhysicsSystem_GetActiveBodiesUnsafe(const JPH_PhysicsSystem* system, JPH_BodyType type)
+{
+    // Returns a direct pointer to Jolt's internal BodyID array
+	return reinterpret_cast<const JPH_BodyID*>(system->physicsSystem->GetActiveBodiesUnsafe(static_cast<JPH::EBodyType>(type)));
+}
+
 uint32_t JPH_PhysicsSystem_GetMaxBodies(const JPH_PhysicsSystem* system)
 {
 	JPH_ASSERT(system);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -760,7 +760,7 @@ bool JPH_Init()
 	if (s_initialized)
 		return true;
 
-	std::cout << ">>> [CULVERIN] LOADING PATCHED JOLTC (MALLOC ALLOCATOR) <<<" << std::endl;
+	std::cout << ">>> TempAllocator implementation with malloc fallback from JoltC... <<<" << std::endl;
 
 	JPH::RegisterDefaultAllocator();
 
@@ -775,7 +775,8 @@ bool JPH_Init()
 	JPH::RegisterTypes();
 
 	// Init temp allocator
-	s_TempAllocator = new TempAllocatorMalloc(); 
+	s_TempAllocator = new TempAllocatorImplWithMallocFallback(8 * 1024 * 1024); 
+	// s_TempAllocator = new TempAllocatorMalloc(); 
 	s_initialized = true;
 
 	return true;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -10754,6 +10754,27 @@ void JPH_WheeledVehicleControllerSettings_SetDifferentials(JPH_WheeledVehicleCon
 	}
 }
 
+// Helper to ensure a wheel is driven without manual diff setup
+JPH_CAPI void JPH_WheeledVehicleControllerSettings_AddDifferential(JPH_WheeledVehicleControllerSettings* settings, int leftWheel, int rightWheel)
+{
+    JPH_ASSERT(settings);
+    VehicleDifferentialSettings diff;
+    diff.mLeftWheel = leftWheel;
+    diff.mRightWheel = rightWheel;
+    diff.mDifferentialRatio = 3.5f; 
+    diff.mLimitedSlipRatio = 1.4f;
+    diff.mEngineTorqueRatio = 1.0f; // This is normalized automatically when multiple are added
+
+    auto* controller = AsWheeledVehicleControllerSettings(settings);
+    controller->mDifferentials.push_back(diff);
+    
+    // Ensure torque is split evenly across all differentials (e.g. 0.5 for Front, 0.5 for Rear)
+    float ratio = 1.0f / (float)controller->mDifferentials.size();
+    for (auto& d : controller->mDifferentials) {
+        d.mEngineTorqueRatio = ratio;
+    }
+}
+
 float JPH_WheeledVehicleControllerSettings_GetDifferentialLimitedSlipRatio(const JPH_WheeledVehicleControllerSettings* settings)
 {
 	return AsWheeledVehicleControllerSettings(settings)->mDifferentialLimitedSlipRatio;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -773,7 +773,7 @@ bool JPH_Init()
 	JPH::RegisterTypes();
 
 	// Init temp allocator
-	s_TempAllocator = new TempAllocatorImplWithMallocFallback(8 * 1024 * 1024);
+	s_TempAllocator = new TempAllocatorMalloc(); 
 	s_initialized = true;
 
 	return true;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -760,8 +760,6 @@ bool JPH_Init()
 	if (s_initialized)
 		return true;
 
-	std::cout << ">>> TempAllocator implementation with malloc fallback from JoltC... <<<" << std::endl;
-
 	JPH::RegisterDefaultAllocator();
 
 	// TODO

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -77,7 +77,7 @@ JPH_SUPPRESS_WARNINGS
 #include "Jolt/Physics/Vehicle/VehicleTrack.h"
 #include "Jolt/Core/LinearCurve.h"
 
-#include <iostream>
+#include <cstdio>
 #include <cstdarg>
 
 // All Jolt symbols are in the JPH namespace
@@ -228,18 +228,20 @@ static void TraceImpl(const char* fmt, ...)
 	// Format the message
 	va_list list;
 	va_start(list, fmt);
-	char buffer[1024];
-	vsnprintf(buffer, sizeof(buffer), fmt, list);
-	va_end(list);
-
+	
 	// Print to the TTY
 	if (s_TraceFunc)
 	{
+		char buffer[1024];
+		vsnprintf(buffer, sizeof(buffer), fmt, list);
+		va_end(list);
 		s_TraceFunc(buffer);
 	}
 	else
 	{
-		std::cout << buffer << std::endl;
+		vfprintf(stdout, fmt, list);
+        printf("\n");
+        fflush(stdout);
 	}
 }
 
@@ -255,7 +257,7 @@ static bool AssertFailedImpl(const char* inExpression, const char* inMessage, co
 	}
 
 	// Print to the TTY
-	std::cout << inFile << ":" << inLine << ": (" << inExpression << ") " << (inMessage != nullptr ? inMessage : "") << std::endl;
+	fprintf(stderr, "%s:%u: (%s) %s\n", inFile, inLine, inExpression, (inMessage != nullptr) ? inMessage : "");
 
 	// Breakpoint
 	return true;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -5263,6 +5263,18 @@ uint32_t JPH_PhysicsSystem_GetNumActiveBodies(const JPH_PhysicsSystem* system, J
 	return system->physicsSystem->GetNumActiveBodies(static_cast<JPH::EBodyType>(type));
 }
 
+JPH_CAPI void JPH_PhysicsSystem_GetActiveBodies(const JPH_PhysicsSystem* system, JPH_BodyID* ids, uint32_t count)
+{
+	JPH::BodyIDVector activeBodies;
+	// The enum value is RigidBody
+	system->physicsSystem->GetActiveBodies(JPH::EBodyType::RigidBody, activeBodies);
+    
+	uint32_t copyCount = std::min(count, (uint32_t)activeBodies.size());
+	for (uint32_t i = 0; i < copyCount; i++) {
+		ids[i] = activeBodies[i].GetIndexAndSequenceNumber();
+	}
+}
+
 uint32_t JPH_PhysicsSystem_GetMaxBodies(const JPH_PhysicsSystem* system)
 {
 	JPH_ASSERT(system);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -10325,6 +10325,11 @@ void JPH_VehicleTransmissionSettings_SetClutchStrength(JPH_VehicleTransmissionSe
 }
 
 /* VehicleTransmission */
+void JPH_VehicleTransmission_SetMode(JPH_VehicleTransmission* transmission, JPH_TransmissionMode mode)
+{
+    AsVehicleTransmission(transmission)->mMode = static_cast<JPH::ETransmissionMode>(mode);
+}
+
 void JPH_VehicleTransmission_Set(JPH_VehicleTransmission* transmission, int currentGear, float clutchFriction)
 {
 	AsVehicleTransmission(transmission)->Set(currentGear, clutchFriction);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -760,6 +760,8 @@ bool JPH_Init()
 	if (s_initialized)
 		return true;
 
+	printf("[Culverin-Internal] JoltC Fork Loaded with TempAllocatorMalloc\n");
+
 	JPH::RegisterDefaultAllocator();
 
 	// TODO

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -5614,6 +5614,11 @@ bool JPH_BodyInterface_IsAdded(JPH_BodyInterface* bodyInterface, JPH_BodyID body
 	return AsBodyInterface(bodyInterface)->IsAdded(JPH::BodyID(bodyID));
 }
 
+JPH_CAPI const JPH_Body* JPH_PhysicsSystem_GetBodyPtr(const JPH_PhysicsSystem* system, JPH_BodyID bodyID)
+{
+	return reinterpret_cast<const JPH_Body*>(system->physicsSystem->GetBodyLockInterface().TryGetBody(JPH::BodyID(bodyID)));
+}
+
 JPH_BodyType JPH_BodyInterface_GetBodyType(JPH_BodyInterface* bodyInterface, JPH_BodyID bodyID)
 {
 	return static_cast<JPH_BodyType>(AsBodyInterface(bodyInterface)->GetBodyType(JPH::BodyID(bodyID)));

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -584,6 +584,24 @@ static inline void ToJolt(ContactSettings& jolt, const JPH_ContactSettings* sett
 	jolt.mRelativeAngularSurfaceVelocity = ToJolt(settings->relativeAngularSurfaceVelocity);
 }
 
+static void ToJolt(JPH::VehicleTrackSettings& joltTrack, const JPH_VehicleTrackSettings* track)
+{
+	joltTrack.mDrivenWheel = track->drivenWheel;
+	joltTrack.mInertia = track->inertia;
+	joltTrack.mAngularDamping = track->angularDamping;
+	joltTrack.mMaxBrakeTorque = track->maxBrakeTorque;
+	joltTrack.mDifferentialRatio = track->differentialRatio;
+
+	joltTrack.mWheels.clear();
+	if (track->wheels && track->wheelsCount > 0)
+	{
+		for (uint32_t i = 0; i < track->wheelsCount; ++i)
+		{
+			joltTrack.mWheels.push_back(track->wheels[i]);
+		}
+	}
+}
+
 void JPH_MassProperties_DecomposePrincipalMomentsOfInertia(JPH_MassProperties* properties, JPH_Mat4* rotation, JPH_Vec3* diagonal)
 {
 	JPH::Mat44 joltRotation;
@@ -10953,6 +10971,20 @@ JPH_CAPI void JPH_TrackedVehicleControllerSettings_SetTransmission(JPH_TrackedVe
 	JPH_ASSERT(value);
 
 	AsTrackedVehicleControllerSettings(settings)->mTransmission = *AsVehicleTransmissionSettings(value);
+}
+
+JPH_CAPI void JPH_TrackedVehicleControllerSettings_SetTrack(JPH_TrackedVehicleControllerSettings* settings, uint32_t index, const JPH_VehicleTrackSettings* track)
+{
+	JPH_ASSERT(settings);
+	JPH_ASSERT(track);
+	
+	// Jolt only supports 2 tracks (Left=0, Right=1)
+	if (index >= 2) return; 
+
+	JPH::VehicleTrackSettings joltTrack;
+	ToJolt(joltTrack, track);
+
+	AsTrackedVehicleControllerSettings(settings)->mTracks[index] = joltTrack;
 }
 
 void JPH_TrackedVehicleController_SetDriverInput(JPH_TrackedVehicleController* controller, float forward, float leftRatio, float rightRatio, float brake)

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -74,6 +74,7 @@ JPH_SUPPRESS_WARNINGS
 #include "Jolt/Physics/Vehicle/WheeledVehicleController.h"
 #include "Jolt/Physics/Vehicle/MotorcycleController.h"
 #include "Jolt/Physics/Vehicle/TrackedVehicleController.h"
+#include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
 #include "Jolt/Physics/Vehicle/VehicleTrack.h"
 #include "Jolt/Core/LinearCurve.h"
 
@@ -3784,21 +3785,47 @@ void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, ui
     AsSoftBodySharedSettings(settings)->mFaces.push_back(f);
 }
 
-void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings) 
+void JPH_SoftBodySharedSettings_CreateConstraints(JPH_SoftBodySharedSettings* settings, float compliance, JPH_SoftBodyBendType bendType) 
 {
-    auto joltSettings = AsSoftBodySharedSettings(settings);
-    
-    // Create default attributes (zero compliance = stiff edges)
+    auto* joltSettings = AsSoftBodySharedSettings(settings);
     JPH::Array<JPH::SoftBodySharedSettings::VertexAttributes> attributes;
     attributes.resize(joltSettings->mVertices.size());
 
-    // Generate internal constraints (springs)
-    // This is required for the simulation to even start.
+    for (auto &attr : attributes) {
+        attr.mCompliance = compliance; 
+        attr.mShearCompliance = compliance; 
+    }
+
     joltSettings->CreateConstraints(attributes.data(), (JPH::uint)attributes.size(), 
-                                    JPH::SoftBodySharedSettings::EBendType::Distance);
-    
-    // Build spatial collision tree
-    joltSettings->Optimize();
+                                    static_cast<JPH::SoftBodySharedSettings::EBendType>(bendType));
+}
+
+void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings) 
+{
+    AsSoftBodySharedSettings(settings)->Optimize();
+}
+
+void JPH_SoftBodySharedSettings_AddPinnedVertex(JPH_SoftBodySharedSettings* settings, uint32_t index)
+{
+    auto* joltSettings = AsSoftBodySharedSettings(settings);
+    if (index < joltSettings->mVertices.size()) {
+        // Setting Inverse Mass to 0 pins the vertex in space relative to center of mass
+        joltSettings->mVertices[index].mInvMass = 0.0f;
+    }
+}
+
+void JPH_SoftBodySharedSettings_GetVertexPosition(const JPH_SoftBodySharedSettings* settings, uint32_t index, JPH_Vec3* outPos)
+{
+    auto* joltSettings = AsSoftBodySharedSettings(settings);
+    if (index < joltSettings->mVertices.size()) {
+        const auto& v = joltSettings->mVertices[index].mPosition;
+        outPos->x = v.x; outPos->y = v.y; outPos->z = v.z;
+    }
+}
+
+uint32_t JPH_SoftBodySharedSettings_GetVertexCount(const JPH_SoftBodySharedSettings* settings) 
+{
+    return settings ? (uint32_t)AsSoftBodySharedSettings(settings)->mVertices.size() : 0;
 }
 
 /* JPH_SoftBodyCreationSettings */
@@ -3854,6 +3881,56 @@ void JPH_SoftBodyCreationSettings_SetObjectLayer(JPH_SoftBodyCreationSettings* s
 void JPH_SoftBodyCreationSettings_SetAllowSleeping(JPH_SoftBodyCreationSettings* settings, bool value)
 {
     AsSoftBodyCreationSettings(settings)->mAllowSleeping = value;
+}
+
+void JPH_SoftBodyCreationSettings_SetPressure(JPH_SoftBodyCreationSettings* settings, float pressure) 
+{
+    AsSoftBodyCreationSettings(settings)->mPressure = pressure;
+}
+
+void JPH_SoftBodyCreationSettings_SetLinearDamping(JPH_SoftBodyCreationSettings* settings, float damping) 
+{
+    AsSoftBodyCreationSettings(settings)->mLinearDamping = damping;
+}
+
+void JPH_SoftBodyCreationSettings_SetNumIterations(JPH_SoftBodyCreationSettings* settings, uint32_t iterations) 
+{
+    AsSoftBodyCreationSettings(settings)->mNumIterations = iterations;
+}
+
+void JPH_SoftBodyCreationSettings_SetMaxLinearVelocity(JPH_SoftBodyCreationSettings* settings, float max_vel) 
+{
+    AsSoftBodyCreationSettings(settings)->mMaxLinearVelocity = max_vel;
+}
+
+void JPH_SoftBodyCreationSettings_SetGravityFactor(JPH_SoftBodyCreationSettings* settings, float gravityFactor) 
+{
+    AsSoftBodyCreationSettings(settings)->mGravityFactor = gravityFactor;
+}
+
+void JPH_SoftBodyCreationSettings_SetFriction(JPH_SoftBodyCreationSettings* settings, float friction) 
+{
+    AsSoftBodyCreationSettings(settings)->mFriction = friction;
+}
+
+void JPH_SoftBodyCreationSettings_SetRestitution(JPH_SoftBodyCreationSettings* settings, float restitution) 
+{
+    AsSoftBodyCreationSettings(settings)->mRestitution = restitution;
+}
+
+void JPH_SoftBodyCreationSettings_SetMakeRotationIdentity(JPH_SoftBodyCreationSettings* settings, bool value) 
+{
+    AsSoftBodyCreationSettings(settings)->mMakeRotationIdentity = value;
+}
+
+float JPH_SoftBodyCreationSettings_GetVertexRadius(const JPH_SoftBodyCreationSettings* settings) 
+{
+    return settings ? AsSoftBodyCreationSettings(settings)->mVertexRadius : 0.0f;
+}
+
+bool JPH_SoftBodyCreationSettings_GetMakeRotationIdentity(const JPH_SoftBodyCreationSettings* settings) 
+{
+    return settings ? AsSoftBodyCreationSettings(settings)->mMakeRotationIdentity : false;
 }
 
 /* JPH_ConstraintSettings */
@@ -7606,6 +7683,26 @@ uint64_t JPH_Body_GetUserData(JPH_Body* body)
 JPH_Body* JPH_Body_GetFixedToWorldBody(void)
 {
 	return ToBody(&JPH::Body::sFixedToWorld);
+}
+
+uint32_t JPH_Body_GetSoftBodyVertexCount(const JPH_Body* body) {
+    if (!body || !AsBody(body)->IsSoftBody()) return 0;
+    auto* mp = static_cast<const JPH::SoftBodyMotionProperties*>(AsBody(body)->GetMotionProperties());
+    return (uint32_t)mp->GetVertices().size();
+}
+
+void JPH_Body_GetSoftBodyVertexPosition(const JPH_Body* body, uint32_t index, JPH_Vec3* outPos) {
+    if (!body || !outPos || !AsBody(body)->IsSoftBody()) return;
+    auto* jBody = AsBody(body);
+    auto* mp = static_cast<const JPH::SoftBodyMotionProperties*>(jBody->GetMotionProperties());
+    if (index >= mp->GetVertices().size()) return;
+
+    const auto& v = mp->GetVertices()[index];
+    JPH::RVec3 worldPos = jBody->GetCenterOfMassTransform() * v.mPosition;
+
+    outPos->x = (float)worldPos.GetX();
+    outPos->y = (float)worldPos.GetY();
+    outPos->z = (float)worldPos.GetZ();
 }
 
 /* Contact Listener */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -74,12 +74,14 @@ JPH_SUPPRESS_WARNINGS
 #include "Jolt/Physics/Vehicle/WheeledVehicleController.h"
 #include "Jolt/Physics/Vehicle/MotorcycleController.h"
 #include "Jolt/Physics/Vehicle/TrackedVehicleController.h"
-#include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
+#include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
+#include "Jolt/Physics/SoftBody/SoftBodySharedSettings.h"
 #include "Jolt/Physics/Vehicle/VehicleTrack.h"
 #include "Jolt/Core/LinearCurve.h"
 
 #include <cstdio>
 #include <cstdarg>
+#include <algorithm>
 
 // All Jolt symbols are in the JPH namespace
 using namespace JPH;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -7750,7 +7750,7 @@ void JPH_Body_GetSoftBodyVertexPosition(const JPH_Body* body, uint32_t index, JP
     outPos->z = (float)worldPos.GetZ();
 }
 
-void JPH_Body_GetSoftBodyVertexPositions(const JPH_Body* body, JPH_Vec3* outPositions, uint32_t* outCount) 
+void JPH_Body_GetSoftBodyVertexPositions(const JPH_Body* body, JPH_Vec3* outPositions, uint32_t capacity, uint32_t* outCount) 
 {
     if (!body || !outPositions || !AsBody(body)->IsSoftBody()) {
         if (outCount) *outCount = 0;
@@ -7761,23 +7761,18 @@ void JPH_Body_GetSoftBodyVertexPositions(const JPH_Body* body, JPH_Vec3* outPosi
     auto* mp = static_cast<const JPH::SoftBodyMotionProperties*>(jBody->GetMotionProperties());
     const JPH::Array<JPH::SoftBodyVertex>& vertices = mp->GetVertices();
     const uint32_t numVertices = (uint32_t)vertices.size();
+    const uint32_t writeCount = (capacity < numVertices) ? capacity : numVertices;
 
-    // Cache the Center of Mass transform to avoid re-calculating inside the loop
     JPH::RMat44 com_transform = jBody->GetCenterOfMassTransform();
 
-    for (uint32_t i = 0; i < numVertices; ++i) {
-        // Transform local vertex to world space
-        // Note: Jolt soft body vertices are local to the COM
+    for (uint32_t i = 0; i < writeCount; ++i) {
         JPH::RVec3 worldPos = com_transform * vertices[i].mPosition;
-
         outPositions[i].x = (float)worldPos.GetX();
         outPositions[i].y = (float)worldPos.GetY();
         outPositions[i].z = (float)worldPos.GetZ();
     }
 
-    if (outCount) {
-        *outCount = numVertices;
-    }
+    if (outCount) *outCount = numVertices; // always report true count, not writeCount
 }
 
 /* Contact Listener */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -113,6 +113,7 @@ using namespace JPH;
 DEF_MAP_DECL(ContactManifold, JPH_ContactManifold)
 DEF_MAP_DECL(BodyCreationSettings, JPH_BodyCreationSettings)
 DEF_MAP_DECL(SoftBodyCreationSettings, JPH_SoftBodyCreationSettings)
+DEF_MAP_DECL(SoftBodySharedSettings, JPH_SoftBodySharedSettings)
 DEF_MAP_DECL(Body, JPH_Body)
 DEF_MAP_DECL(BodyInterface, JPH_BodyInterface)
 DEF_MAP_DECL(BodyLockInterface, JPH_BodyLockInterface)
@@ -3745,6 +3746,44 @@ void JPH_BodyCreationSettings_SetMassPropertiesOverride(JPH_BodyCreationSettings
 	AsBodyCreationSettings(settings)->mMassPropertiesOverride = ToJolt(massProperties);
 }
 
+/* JPH_SoftBodySharedSettings */
+JPH_SoftBodySharedSettings* JPH_SoftBodySharedSettings_Create(void) 
+{
+    auto settings = new JPH::SoftBodySharedSettings();
+    settings->AddRef();
+    return ToSoftBodySharedSettings(settings);
+}
+
+void JPH_SoftBodySharedSettings_Destroy(JPH_SoftBodySharedSettings* settings) 
+{
+    if (settings) 
+	{
+		AsSoftBodySharedSettings(settings)->Release();
+	}
+}
+
+void JPH_SoftBodySharedSettings_AddVertex(JPH_SoftBodySharedSettings* settings, const JPH_Vec3* position, float invMass) 
+{
+    JPH::SoftBodySharedSettings::Vertex v;
+    v.mPosition = JPH::Float3(position->x, position->y, position->z);
+    v.mInvMass = invMass;
+    AsSoftBodySharedSettings(settings)->mVertices.push_back(v);
+}
+
+void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, uint32_t vertex1, uint32_t vertex2, uint32_t vertex3) 
+{
+    JPH::SoftBodySharedSettings::Face f;
+    f.mVertex[0] = vertex1;
+    f.mVertex[1] = vertex2;
+    f.mVertex[2] = vertex3;
+    AsSoftBodySharedSettings(settings)->mFaces.push_back(f);
+}
+
+void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings) {
+    // Calculates normals, edge constraints, etc.
+    AsSoftBodySharedSettings(settings)->Optimize(); 
+}
+
 /* JPH_SoftBodyCreationSettings */
 JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void)
 {
@@ -3758,6 +3797,11 @@ void JPH_SoftBodyCreationSettings_Destroy(JPH_SoftBodyCreationSettings* settings
 	{
 		delete AsSoftBodyCreationSettings(settings);
 	}
+}
+
+void JPH_SoftBodyCreationSettings_SetSharedSettings(JPH_SoftBodyCreationSettings* settings, const JPH_SoftBodySharedSettings* sharedSettings) 
+{
+    AsSoftBodyCreationSettings(settings)->mSettings = AsSoftBodySharedSettings(sharedSettings);
 }
 
 /* JPH_ConstraintSettings */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -764,19 +764,25 @@ bool JPH_Init()
 
 	JPH::RegisterDefaultAllocator();
 
-	// TODO
 	JPH::Trace = TraceImpl;
 	JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = AssertFailedImpl;)
 
-		// Create a factory
-		JPH::Factory::sInstance = new JPH::Factory();
+	// Create a factory
+	JPH::Factory::sInstance = new JPH::Factory();
 
 	// Register all Jolt physics types
 	JPH::RegisterTypes();
-
-	// Init temp allocator
+	
+#if defined(__SANITIZE_THREAD__) || defined(ENABLE_SANITIZER)
+	// ThreadSanitizer does not understand Jolt's lock-free 8MB bump allocator
+	// and will flag cross-frame memory reuse as data races.
+	// We fall back to standard malloc/free which TSan can track perfectly.
+	s_TempAllocator = new TempAllocatorMalloc(); 
+#else
+	// High-performance lock-free allocator for production
 	s_TempAllocator = new TempAllocatorImplWithMallocFallback(8 * 1024 * 1024); 
-	// s_TempAllocator = new TempAllocatorMalloc(); 
+#endif
+
 	s_initialized = true;
 
 	return true;

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -1771,6 +1771,13 @@ void JPH_Vec3_DivideScalar(const JPH_Vec3* v, float scalar, JPH_Vec3* result)
 	FromJolt(joltVec / scalar, result);
 }
 
+void JPH_Vec3_GetNormalizedPerpendicular(const JPH_Vec3* v, JPH_Vec3* result)
+{
+	JPH_ASSERT(v && result);
+	JPH::Vec3 joltVec = ToJolt(v);
+	FromJolt(joltVec.GetNormalizedPerpendicular(), result);
+}
+
 void JPH_Vec3_DotProduct(const JPH_Vec3* v1, const JPH_Vec3* v2, float* result)
 {
 	JPH_ASSERT(v1 && v2 && result);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -3750,8 +3750,7 @@ void JPH_BodyCreationSettings_SetMassPropertiesOverride(JPH_BodyCreationSettings
 JPH_SoftBodySharedSettings* JPH_SoftBodySharedSettings_Create(void) 
 {
     auto settings = new JPH::SoftBodySharedSettings();
-	// Soft bodies require at least one material to be present in the array 
-    // to resolve face collisions, otherwise Jolt reads out of bounds during initialization.
+    // Jolt requires at least one material to resolve face collisions
     settings->mMaterials.push_back(JPH::PhysicsMaterial::sDefault);
     settings->AddRef();
     return ToSoftBodySharedSettings(settings);
@@ -3768,8 +3767,9 @@ void JPH_SoftBodySharedSettings_Destroy(JPH_SoftBodySharedSettings* settings)
 void JPH_SoftBodySharedSettings_AddVertex(JPH_SoftBodySharedSettings* settings, const JPH_Vec3* position, float invMass) 
 {
     JPH::SoftBodySharedSettings::Vertex v;
-    v.mPosition = JPH::Float3(position->x, position->y, position->z);
-	v.mVelocity = JPH::Float3(0, 0, 0);
+    // Jolt soft body vertices are always Float3 even in Double Precision mode
+    v.mPosition = JPH::Float3((float)position->x, (float)position->y, (float)position->z);
+    v.mVelocity = JPH::Float3(0, 0, 0); // Zero out to avoid explosion
     v.mInvMass = invMass;
     AsSoftBodySharedSettings(settings)->mVertices.push_back(v);
 }
@@ -3784,9 +3784,21 @@ void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, ui
     AsSoftBodySharedSettings(settings)->mFaces.push_back(f);
 }
 
-void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings) {
-    // Calculates normals, edge constraints, etc.
-    AsSoftBodySharedSettings(settings)->Optimize(); 
+void JPH_SoftBodySharedSettings_Optimize(JPH_SoftBodySharedSettings* settings) 
+{
+    auto joltSettings = AsSoftBodySharedSettings(settings);
+    
+    // Create default attributes (zero compliance = stiff edges)
+    JPH::Array<JPH::SoftBodySharedSettings::VertexAttributes> attributes;
+    attributes.resize(joltSettings->mVertices.size());
+
+    // Generate internal constraints (springs)
+    // This is required for the simulation to even start.
+    joltSettings->CreateConstraints(attributes.data(), (JPH::uint)attributes.size(), 
+                                    JPH::SoftBodySharedSettings::EBendType::Distance);
+    
+    // Build spatial collision tree
+    joltSettings->Optimize();
 }
 
 /* JPH_SoftBodyCreationSettings */
@@ -3807,6 +3819,41 @@ void JPH_SoftBodyCreationSettings_Destroy(JPH_SoftBodyCreationSettings* settings
 void JPH_SoftBodyCreationSettings_SetSharedSettings(JPH_SoftBodyCreationSettings* settings, const JPH_SoftBodySharedSettings* sharedSettings) 
 {
     AsSoftBodyCreationSettings(settings)->mSettings = AsSoftBodySharedSettings(sharedSettings);
+}
+
+void JPH_SoftBodyCreationSettings_SetVertexRadius(JPH_SoftBodyCreationSettings* settings, float radius) 
+{
+    AsSoftBodyCreationSettings(settings)->mVertexRadius = radius;
+}
+
+void JPH_SoftBodyCreationSettings_SetUserData(JPH_SoftBodyCreationSettings* settings, uint64_t userData) 
+{
+    AsSoftBodyCreationSettings(settings)->mUserData = userData;
+}
+
+void JPH_SoftBodyCreationSettings_SetCollisionGroup(JPH_SoftBodyCreationSettings* settings, const JPH_CollisionGroup* group) 
+{
+    AsSoftBodyCreationSettings(settings)->mCollisionGroup = ToJolt(group);
+}
+
+void JPH_SoftBodyCreationSettings_SetPosition(JPH_SoftBodyCreationSettings* settings, const JPH_RVec3* value)
+{
+    AsSoftBodyCreationSettings(settings)->mPosition = ToJolt(value);
+}
+
+void JPH_SoftBodyCreationSettings_SetRotation(JPH_SoftBodyCreationSettings* settings, const JPH_Quat* value)
+{
+    AsSoftBodyCreationSettings(settings)->mRotation = ToJolt(value);
+}
+
+void JPH_SoftBodyCreationSettings_SetObjectLayer(JPH_SoftBodyCreationSettings* settings, JPH_ObjectLayer value)
+{
+    AsSoftBodyCreationSettings(settings)->mObjectLayer = static_cast<JPH::ObjectLayer>(value);
+}
+
+void JPH_SoftBodyCreationSettings_SetAllowSleeping(JPH_SoftBodyCreationSettings* settings, bool value)
+{
+    AsSoftBodyCreationSettings(settings)->mAllowSleeping = value;
 }
 
 /* JPH_ConstraintSettings */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -3828,6 +3828,51 @@ uint32_t JPH_SoftBodySharedSettings_GetVertexCount(const JPH_SoftBodySharedSetti
     return settings ? (uint32_t)AsSoftBodySharedSettings(settings)->mVertices.size() : 0;
 }
 
+void JPH_SoftBodySharedSettings_AddVertices(
+    JPH_SoftBodySharedSettings* settings,
+    const JPH_Vec3* positions,
+    const float* invMasses,
+    uint32_t count)
+{
+    if (!settings || !positions || count == 0) return;
+
+    auto* s = AsSoftBodySharedSettings(settings);
+    
+    // Performance: Allocate memory once for the entire batch
+    s->mVertices.reserve(s->mVertices.size() + count);
+
+    for (uint32_t i = 0; i < count; i++) {
+        JPH::SoftBodySharedSettings::Vertex v;
+        // Jolt Soft Body vertices are always Float3
+        v.mPosition = JPH::Float3(positions[i].x, positions[i].y, positions[i].z);
+        v.mVelocity = JPH::Float3(0, 0, 0);
+        v.mInvMass  = invMasses ? invMasses[i] : 1.0f;
+        s->mVertices.push_back(v);
+    }
+}
+
+void JPH_SoftBodySharedSettings_AddFaces(
+    JPH_SoftBodySharedSettings* settings,
+    const uint32_t* indices,
+    uint32_t face_count)
+{
+    if (!settings || !indices || face_count == 0) return;
+
+    auto* s = AsSoftBodySharedSettings(settings);
+    
+    // Performance: Avoid per-face reallocations
+    s->mFaces.reserve(s->mFaces.size() + face_count);
+
+    for (uint32_t i = 0; i < face_count; i++) {
+        JPH::SoftBodySharedSettings::Face f;
+        f.mVertex[0]    = indices[i * 3 + 0];
+        f.mVertex[1]    = indices[i * 3 + 1];
+        f.mVertex[2]    = indices[i * 3 + 2];
+        f.mMaterialIndex = 0;
+        s->mFaces.push_back(f);
+    }
+}
+
 /* JPH_SoftBodyCreationSettings */
 JPH_SoftBodyCreationSettings* JPH_SoftBodyCreationSettings_Create(void)
 {
@@ -7703,6 +7748,36 @@ void JPH_Body_GetSoftBodyVertexPosition(const JPH_Body* body, uint32_t index, JP
     outPos->x = (float)worldPos.GetX();
     outPos->y = (float)worldPos.GetY();
     outPos->z = (float)worldPos.GetZ();
+}
+
+void JPH_Body_GetSoftBodyVertexPositions(const JPH_Body* body, JPH_Vec3* outPositions, uint32_t* outCount) 
+{
+    if (!body || !outPositions || !AsBody(body)->IsSoftBody()) {
+        if (outCount) *outCount = 0;
+        return;
+    }
+
+    const JPH::Body* jBody = AsBody(body);
+    auto* mp = static_cast<const JPH::SoftBodyMotionProperties*>(jBody->GetMotionProperties());
+    const JPH::Array<JPH::SoftBodyVertex>& vertices = mp->GetVertices();
+    const uint32_t numVertices = (uint32_t)vertices.size();
+
+    // Cache the Center of Mass transform to avoid re-calculating inside the loop
+    JPH::RMat44 com_transform = jBody->GetCenterOfMassTransform();
+
+    for (uint32_t i = 0; i < numVertices; ++i) {
+        // Transform local vertex to world space
+        // Note: Jolt soft body vertices are local to the COM
+        JPH::RVec3 worldPos = com_transform * vertices[i].mPosition;
+
+        outPositions[i].x = (float)worldPos.GetX();
+        outPositions[i].y = (float)worldPos.GetY();
+        outPositions[i].z = (float)worldPos.GetZ();
+    }
+
+    if (outCount) {
+        *outCount = numVertices;
+    }
 }
 
 /* Contact Listener */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -942,6 +942,24 @@ JPH_ObjectVsBroadPhaseLayerFilter* JPH_ObjectVsBroadPhaseLayerFilterTable_Create
 	return reinterpret_cast<JPH_ObjectVsBroadPhaseLayerFilter*>(filter);
 }
 
+void JPH_BroadPhaseLayerInterfaceTable_Destroy(JPH_BroadPhaseLayerInterface* bpInterface)
+{
+    if (bpInterface)
+        delete reinterpret_cast<JPH::BroadPhaseLayerInterfaceTable*>(bpInterface);
+}
+
+void JPH_ObjectLayerPairFilterTable_Destroy(JPH_ObjectLayerPairFilter* filter)
+{
+    if (filter)
+        delete reinterpret_cast<JPH::ObjectLayerPairFilterTable*>(filter);
+}
+
+void JPH_ObjectVsBroadPhaseLayerFilterTable_Destroy(JPH_ObjectVsBroadPhaseLayerFilter* filter)
+{
+    if (filter)
+        delete reinterpret_cast<JPH::ObjectVsBroadPhaseLayerFilterTable*>(filter);
+}
+
 void JPH_DrawSettings_InitDefault(JPH_DrawSettings* settings)
 {
 	JPH_ASSERT(settings);

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -3750,6 +3750,9 @@ void JPH_BodyCreationSettings_SetMassPropertiesOverride(JPH_BodyCreationSettings
 JPH_SoftBodySharedSettings* JPH_SoftBodySharedSettings_Create(void) 
 {
     auto settings = new JPH::SoftBodySharedSettings();
+	// Soft bodies require at least one material to be present in the array 
+    // to resolve face collisions, otherwise Jolt reads out of bounds during initialization.
+    settings->mMaterials.push_back(JPH::PhysicsMaterial::sDefault);
     settings->AddRef();
     return ToSoftBodySharedSettings(settings);
 }

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -3766,6 +3766,7 @@ void JPH_SoftBodySharedSettings_AddVertex(JPH_SoftBodySharedSettings* settings, 
 {
     JPH::SoftBodySharedSettings::Vertex v;
     v.mPosition = JPH::Float3(position->x, position->y, position->z);
+	v.mVelocity = JPH::Float3(0, 0, 0);
     v.mInvMass = invMass;
     AsSoftBodySharedSettings(settings)->mVertices.push_back(v);
 }
@@ -3776,6 +3777,7 @@ void JPH_SoftBodySharedSettings_AddFace(JPH_SoftBodySharedSettings* settings, ui
     f.mVertex[0] = vertex1;
     f.mVertex[1] = vertex2;
     f.mVertex[2] = vertex3;
+	f.mMaterialIndex = 0;
     AsSoftBodySharedSettings(settings)->mFaces.push_back(f);
 }
 

--- a/src/joltc_assert.cpp
+++ b/src/joltc_assert.cpp
@@ -225,8 +225,15 @@ static_assert((int)JPH_SoftBodyBendType_Dihedral == (int)JPH::SoftBodySharedSett
 
 #if defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__)
     // 64-bit Platform Sizes
-    static_assert(sizeof(JPH::BodyCreationSettings) == 288 || sizeof(JPH::BodyCreationSettings) == 256);
-    static_assert(sizeof(JPH::SoftBodyCreationSettings) == 160 || sizeof(JPH::SoftBodyCreationSettings) == 144);
+    static_assert(
+        sizeof(JPH::BodyCreationSettings) == 288 || 
+        sizeof(JPH::BodyCreationSettings) == 256
+    );
+    static_assert(
+        sizeof(JPH::SoftBodyCreationSettings) == 160 || 
+        sizeof(JPH::SoftBodyCreationSettings) == 144 || 
+        sizeof(JPH::SoftBodyCreationSettings) == 128
+    );
 #endif
 
 #ifdef JPH_DEBUG_RENDERER

--- a/src/joltc_assert.cpp
+++ b/src/joltc_assert.cpp
@@ -222,8 +222,12 @@ static_assert((int)JPH_SoftBodyBendType_None == (int)JPH::SoftBodySharedSettings
 static_assert((int)JPH_SoftBodyBendType_Distance == (int)JPH::SoftBodySharedSettings::EBendType::Distance);
 static_assert((int)JPH_SoftBodyBendType_Dihedral == (int)JPH::SoftBodySharedSettings::EBendType::Dihedral);
 
-static_assert(sizeof(JPH::BodyCreationSettings) == 288 || sizeof(JPH::BodyCreationSettings) == 256); // Depends on Double Precision
-static_assert(sizeof(JPH::SoftBodyCreationSettings) == 160 || sizeof(JPH::SoftBodyCreationSettings) == 144);
+
+#if defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__)
+    // 64-bit Platform Sizes
+    static_assert(sizeof(JPH::BodyCreationSettings) == 288 || sizeof(JPH::BodyCreationSettings) == 256);
+    static_assert(sizeof(JPH::SoftBodyCreationSettings) == 160 || sizeof(JPH::SoftBodyCreationSettings) == 144);
+#endif
 
 #ifdef JPH_DEBUG_RENDERER
 

--- a/src/joltc_assert.cpp
+++ b/src/joltc_assert.cpp
@@ -26,6 +26,8 @@ __pragma(warning(push, 0))
 #include "Jolt/Physics/Body/BodyCreationSettings.h"
 #include "Jolt/Physics/Body/BodyActivationListener.h"
 #include "Jolt/Physics/Body/AllowedDOFs.h"
+#include <Jolt/Physics/SoftBody/SoftBodySharedSettings.h>
+#include <Jolt/Physics/SoftBody/SoftBodyCreationSettings.h>
 #include "Jolt/Physics/Constraints/SixDOFConstraint.h"
 #include "Jolt/Physics/Character/CharacterBase.h"
 #include "Jolt/Physics/Character/CharacterID.h"
@@ -214,6 +216,14 @@ static_assert(JPH_CollectFacesMode_NoFaces == (int)JPH::ECollectFacesMode::NoFac
 
 static_assert(sizeof(JPH::SubShapeIDPair) == sizeof(JPH_SubShapeIDPair));
 static_assert(alignof(JPH::SubShapeIDPair) == alignof(JPH_SubShapeIDPair));
+
+// EBendType
+static_assert((int)JPH_SoftBodyBendType_None == (int)JPH::SoftBodySharedSettings::EBendType::None);
+static_assert((int)JPH_SoftBodyBendType_Distance == (int)JPH::SoftBodySharedSettings::EBendType::Distance);
+static_assert((int)JPH_SoftBodyBendType_Dihedral == (int)JPH::SoftBodySharedSettings::EBendType::Dihedral);
+
+static_assert(sizeof(JPH::BodyCreationSettings) == 288 || sizeof(JPH::BodyCreationSettings) == 256); // Depends on Double Precision
+static_assert(sizeof(JPH::SoftBodyCreationSettings) == 160 || sizeof(JPH::SoftBodyCreationSettings) == 144);
 
 #ifdef JPH_DEBUG_RENDERER
 


### PR DESCRIPTION
Hi. Here is the summarized list of my changes:

* Full support for creating vertices, faces, and constraints (Distance/Dihedral).
* Creation & Simulation: Exposed all major SoftBodyCreationSettings parameters including pressure, vertex radius, and damping.
* Added both safe (copy) and optimized (direct pointer) methods to retrieve vertex positions from active Soft Bodies.
* Introduced JPH_PhysicsSystem_GetActiveBodiesUnsafe, allowing users to read the internal BodyID array directly, bypassing unnecessary allocations and copies.
* Added batch vertex/face addition to SharedSettings with internal memory reserving to minimize reallocations during asset loading.
* Added a TempAllocatorMalloc fallback in JPH_Init triggered by __SANITIZE_THREAD__. This prevents TSan from flagging Jolt’s custom stack-allocator reuse as data races.
* Refactored JoltPhysics discovery to check provided roots, nested directories, and side-by-side clones before falling back to GitHub.

Thanks!