### PR TITLE
Expose TempAllocator C-API and add explicit allocator support for parallel PhysicsSystem updates

### DIFF
--- a/include/joltc.h
+++ b/include/joltc.h
@@ -3163,6 +3163,5 @@ JPH_CAPI void JPH_TempAllocator_Destroy(JPH_TempAllocator* allocator);
 
 /* Explicit Allocator Variants */
 JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Update2(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_TempAllocator* tempAllocator, JPH_JobSystem* jobSystem);
-JPH_CAPI void JPH_PhysicsSystem_OptimizeBroadPhase2(JPH_PhysicsSystem* system, JPH_TempAllocator* tempAllocator);
 
 #endif /* JOLT_C_H_ */

--- a/include/joltc.h
+++ b/include/joltc.h
@@ -3154,4 +3154,15 @@ JPH_CAPI uint32_t JPH_LinearCurve_GetPointCount(const JPH_LinearCurve* curve);
 JPH_CAPI void JPH_LinearCurve_GetPoint(const JPH_LinearCurve* curve, uint32_t index, JPH_Point* result);
 JPH_CAPI void JPH_LinearCurve_GetPoints(const JPH_LinearCurve* curve, JPH_Point* points, uint32_t* count);
 
+/* Temp Allocator */
+typedef struct JPH_TempAllocator JPH_TempAllocator;
+
+JPH_CAPI JPH_TempAllocator* JPH_TempAllocator_Create(uint32_t size);
+JPH_CAPI JPH_TempAllocator* JPH_TempAllocatorMalloc_Create(void);
+JPH_CAPI void JPH_TempAllocator_Destroy(JPH_TempAllocator* allocator);
+
+/* Explicit Allocator Variants */
+JPH_CAPI JPH_PhysicsUpdateError JPH_PhysicsSystem_Update2(JPH_PhysicsSystem* system, float deltaTime, int collisionSteps, JPH_TempAllocator* tempAllocator, JPH_JobSystem* jobSystem);
+JPH_CAPI void JPH_PhysicsSystem_OptimizeBroadPhase2(JPH_PhysicsSystem* system, JPH_TempAllocator* tempAllocator);
+
 #endif /* JOLT_C_H_ */

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -224,6 +224,8 @@ DEF_MAP_DECL(VehicleConstraint, JPH_VehicleConstraint)
 
 DEF_MAP_DECL(LinearCurve, JPH_LinearCurve)
 
+DEF_MAP_DECL(TempAllocator, JPH_TempAllocator)
+
 // Callback for traces, connect this to your own trace function if you have one
 static JPH_TraceFunc s_TraceFunc = nullptr;
 
@@ -11751,6 +11753,32 @@ void JPH_LinearCurve_GetPoints(const JPH_LinearCurve* curve, JPH_Point* points, 
 			};
 		}
 	}
+}
+
+JPH_TempAllocator *JPH_TempAllocator_Create(uint32_t size)
+{
+    return ToTempAllocator(new TempAllocatorImplWithMallocFallback(size));
+}
+
+JPH_TempAllocator *JPH_TempAllocatorMalloc_Create(void)
+{
+    return ToTempAllocator(new TempAllocatorMalloc());
+}
+
+void JPH_TempAllocator_Destroy(JPH_TempAllocator* allocator) {
+    if (allocator) delete AsTempAllocator(allocator);
+}
+
+JPH_PhysicsUpdateError
+JPH_PhysicsSystem_Update2(JPH_PhysicsSystem *system, float deltaTime, int collisionSteps, JPH_TempAllocator *tempAllocator, JPH_JobSystem *jobSystem)
+{
+    JPH::JobSystem* joltJobSystem = reinterpret_cast<JPH::JobSystem*>(jobSystem);
+    return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, AsTempAllocator(tempAllocator), joltJobSystem));
+}
+
+void JPH_PhysicsSystem_OptimizeBroadPhase2(JPH_PhysicsSystem *system, JPH_TempAllocator *tempAllocator)
+{
+    system->physicsSystem->OptimizeBroadPhase(); // Jolt's OptimizeBroadPhase actually doesn't use TempAllocator in standard builds, but we provide this for symmetry if needed.
 }
 
 JPH_SUPPRESS_WARNING_POP

--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -11776,9 +11776,4 @@ JPH_PhysicsSystem_Update2(JPH_PhysicsSystem *system, float deltaTime, int collis
     return static_cast<JPH_PhysicsUpdateError>(system->physicsSystem->Update(deltaTime, collisionSteps, AsTempAllocator(tempAllocator), joltJobSystem));
 }
 
-void JPH_PhysicsSystem_OptimizeBroadPhase2(JPH_PhysicsSystem *system, JPH_TempAllocator *tempAllocator)
-{
-    system->physicsSystem->OptimizeBroadPhase(); // Jolt's OptimizeBroadPhase actually doesn't use TempAllocator in standard builds, but we provide this for symmetry if needed.
-}
-
 JPH_SUPPRESS_WARNING_POP


### PR DESCRIPTION
Hello.

This updates the binder to support multi-threaded concurrency and multiple PhysicsSystem instances by exposing JPH_TempAllocator and providing explicit allocator variants for simulation updates. Previously there was a global s_TempAllocator, and TempAllocatorImpl is not thread-safe. Attempting to update two physics systems simultaneously on different threads resulted in `Freeing in the wrong order` trace abort.

`JPH_PhysicsSystem_Update2` and `JPH_PhysicsSystem_OptimizeBroadPhase2` now allow the passing of a specific `TempAllocator` instance for multi-world concurrency.

Thanks.