### PR TITLE
Fix memory leaks in CollideShape callbacks by freeing result members

### DIFF
--- a/src/joltc.cpp
+++ b/src/joltc.cpp
@@ -6430,6 +6430,7 @@ public:
 		JPH_CollideShapeResult hit = FromJolt(result);
 
 		float fraction = proc(userData, &hit);
+		JPH_CollideShapeResult_FreeMembers(&hit);
 		UpdateEarlyOutFraction(fraction);
 		hadHit = true;
 	}
@@ -6855,6 +6856,7 @@ bool JPH_NarrowPhaseQuery_CollideShape2(const JPH_NarrowPhaseQuery* query,
 			{
 				result = FromJolt(collector.mHit);
 				callback(userData, &result);
+				JPH_CollideShapeResult_FreeMembers(&result);
 			}
 
 			return collector.HadHit();
@@ -6880,6 +6882,7 @@ bool JPH_NarrowPhaseQuery_CollideShape2(const JPH_NarrowPhaseQuery* query,
 			{
 				result = FromJolt(collector.mHit);
 				callback(userData, &result);
+				JPH_CollideShapeResult_FreeMembers(&result);
 			}
 
 			return collector.HadHit();
@@ -7468,6 +7471,8 @@ public:
 				&baseOffset,
 				&collideShapeResult
 			);
+			
+			JPH_CollideShapeResult_FreeMembers(&collideShapeResult);
 
 			return (JPH::ValidateResult)result;
 		}


### PR DESCRIPTION
CollideShapeResult contains dynamically allocated members that were not
  being freed after use in shape collision callbacks and validators,
  causing memory leaks on repeated collision queries.